### PR TITLE
fix: clear API error state immediately on per-item scan success

### DIFF
--- a/torn-snipe-tracker-v1.user.js
+++ b/torn-snipe-tracker-v1.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn Snipe Tracker
 // @namespace    estradarpm-snipe-tracker
-// @version      1.16.1
+// @version      1.16.2
 // @description  Bazaar snipe detector and trade ledger for Torn City
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/bazaar.php*
@@ -26,7 +26,7 @@
     window.__stPollTimer = null;
   }
 
-  const SCRIPT_VERSION = '1.16.1';
+  const SCRIPT_VERSION = '1.16.2';
   const API_KEY = '###PDA-APIKEY###';
 
   // Prefer PDA-injected key; fall back to manually stored key
@@ -650,9 +650,9 @@
     for (const item of MEM.watchlist) {
       if (!(item.itemId > 0)) continue;
       await fetchItemPrice(item);
+      renderWatchlist(); // clear error state immediately on per-item success
     }
     if (scanLine) scanLine.textContent = `Last scan: ${new Date().toLocaleTimeString()}`;
-    renderWatchlist();
   }
 
   function startPollLoop() {


### PR DESCRIPTION
renderWatchlist() was called once after the full watchlist loop, so a previously-errored item's "API error" badge wouldn't clear until every other item had also finished fetching. Moves renderWatchlist() inside the loop so it fires after each individual fetchItemPrice() call. fetchItemPrice already replaces the entire pollResults object on success (no error field), so the badge clears the moment that item's fetch resolves successfully. Version 1.16.1 → 1.16.2.

https://claude.ai/code/session_01JmPSiNeNhrPpDrPy8kqUw2