### PR TITLE
feat(snapshots): Step 4 — cap snapshot count at 500 entries per item

### DIFF
--- a/torn-snipe-tracker-v1.user.js
+++ b/torn-snipe-tracker-v1.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn Snipe Tracker
 // @namespace    estradarpm-snipe-tracker
-// @version      1.17.2
+// @version      1.17.3
 // @description  Bazaar snipe detector and trade ledger for Torn City
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/bazaar.php*
@@ -27,7 +27,7 @@
     window.__stPollTimer = null;
   }
 
-  const SCRIPT_VERSION = '1.17.2';
+  const SCRIPT_VERSION = '1.17.3';
   const API_KEY = '###PDA-APIKEY###';
 
   // Prefer PDA-injected key; fall back to manually stored key
@@ -639,6 +639,7 @@
       MEM.snapshots[item.itemId].push({ timestamp: Date.now(), listings: rawListings });
       const cutoff = Date.now() - 7 * 24 * 60 * 60 * 1000;
       MEM.snapshots[item.itemId] = MEM.snapshots[item.itemId].filter(s => s.timestamp >= cutoff);
+      if (MEM.snapshots[item.itemId].length > 500) MEM.snapshots[item.itemId] = MEM.snapshots[item.itemId].slice(-500);
       Store.set(KEYS.snapshots, MEM.snapshots);
     } catch (err) {
       console.error(`[SnipeTracker] fetchItemPrice failed for itemId ${item.itemId}:`, err.message);


### PR DESCRIPTION
After age pruning, if the array still exceeds 500 entries, slice(-500) to retain only the 500 most recent. Prevents unbounded localStorage growth on frequently scanned items regardless of the 7-day window. Bump version 1.17.2 → 1.17.3.

https://claude.ai/code/session_01Nxg7U7PeWGSQ3FNRH6xVmY