### PR TITLE
Phase 7 Step 2: trend-informed recommendedSellTarget (v1.23.0)

### DIFF
--- a/torn-snipe-tracker-v1.user.js
+++ b/torn-snipe-tracker-v1.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn Snipe Tracker
 // @namespace    estradarpm-snipe-tracker
-// @version      1.22.0
+// @version      1.23.0
 // @description  Bazaar snipe detector and trade ledger for Torn City
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/bazaar.php*
@@ -27,7 +27,7 @@
     window.__stPollTimer = null;
   }
 
-  const SCRIPT_VERSION = '1.22.0';
+  const SCRIPT_VERSION = '1.23.0';
   const API_KEY = '###PDA-APIKEY###';
 
   // Prefer PDA-injected key; fall back to manually stored key
@@ -737,6 +737,7 @@
       MEM.pollResults[item.itemId] = {
         fairValue:       computeMedian(sample),
         lowestListed:    prices[0] ?? null,
+        secondLowest:    prices[1] ?? null,
         outlierExcluded,
         updatedAt:       Date.now(),
       };
@@ -757,6 +758,14 @@
 
       MEM.trendCache[item.itemId] = { ...calculateTrend(item.itemId), calculatedAt: Date.now() };
       Store.set(KEYS.trendcache, MEM.trendCache);
+
+      const res = MEM.pollResults[item.itemId];
+      const trendSignal = MEM.trendCache[item.itemId].trend;
+      if (trendSignal === 'falling' && res.secondLowest != null) {
+        res.recommendedSellTarget = res.secondLowest;
+      } else {
+        res.recommendedSellTarget = res.fairValue;
+      }
     } catch (err) {
       console.error(`[SnipeTracker] fetchItemPrice failed for itemId ${item.itemId}:`, err.message);
       MEM.pollResults[item.itemId] = { error: true, errorMsg: err.message, updatedAt: Date.now() };


### PR DESCRIPTION
After the trend cache is updated each scan cycle, derive a recommended sell target per item: falling trend → prices[1] (floor above outlier), all other signals → fair value. Stored as res.recommendedSellTarget in pollResults alongside fairValue. Manual overrides (Step 3) will take precedence at render time; this step only populates the calculated value.

https://claude.ai/code/session_01UxmBSKd5Bg68HTitznJeUZ