### PR TITLE
Step 2: parse and merge bazaar + itemmarket listings

### DIFF
--- a/torn-snipe-tracker-v1.user.js
+++ b/torn-snipe-tracker-v1.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn Snipe Tracker
 // @namespace    estradarpm-snipe-tracker
-// @version      1.31.0
+// @version      1.32.0
 // @description  Bazaar snipe detector and trade ledger for Torn City
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/bazaar.php*
@@ -28,7 +28,7 @@
     window.__stPollTimer = null;
   }
 
-  const SCRIPT_VERSION = '1.31.0';
+  const SCRIPT_VERSION = '1.32.0';
   const API_KEY = '###PDA-APIKEY###';
 
   // Prefer PDA-injected key; fall back to manually stored key
@@ -831,24 +831,31 @@
     const weav3rUrl = `https://weav3r.dev/api/marketplace/${item.itemId}`;
     const tornUrl   = `https://api.torn.com/v2/market/${item.itemId}/itemmarket?key=${key}`;
 
-    console.log(`[SnipeTracker] fetch weav3r → marketplace/${item.itemId}`);
+    let bazaarListings  = [];
+    let itemMktListings = [];
+
     try {
       const text = await gmFetch(weav3rUrl);
       const d    = JSON.parse(text);
-      console.log(`[SnipeTracker] weav3r raw response itemId=${item.itemId}:`, JSON.stringify(d));
+      if (d.error) throw new Error(d.error);
+      bazaarListings = (d.listings ?? []).map(l => ({ price: l.price, quantity: l.quantity }));
     } catch (err) {
       console.error(`[SnipeTracker] weav3r fetch failed for itemId ${item.itemId}:`, err.message);
     }
 
-    console.log(`[SnipeTracker] fetch torn → v2/market/${item.itemId}/itemmarket`);
     try {
       const text = await gmFetch(tornUrl);
       const d    = JSON.parse(text);
-      console.log(`[SnipeTracker] torn raw response itemId=${item.itemId}:`, JSON.stringify(d));
+      if (d.error) throw new Error(d.error.error ?? `API error ${d.error.code}`);
+      itemMktListings = (d.itemmarket?.listings ?? []).map(l => ({ price: l.price, quantity: l.amount }));
     } catch (err) {
       console.error(`[SnipeTracker] torn fetch failed for itemId ${item.itemId}:`, err.message);
       MEM.pollResults[item.itemId] = { error: true, errorMsg: err.message, updatedAt: Date.now() };
     }
+
+    const merged = [...bazaarListings, ...itemMktListings].sort((a, b) => a.price - b.price);
+    console.log(`[SnipeTracker] merged listings itemId=${item.itemId}:`, JSON.stringify(merged));
+    // Step 2: merged array logged — no further processing yet
   }
 
   // ─── Poll loop ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Normalize weav3r listings (price/quantity) and Torn itemmarket listings
(price/amount → quantity). Merge into single array sorted ascending by
price. Log merged result to console. No further processing yet.
Bump to v1.32.0.

https://claude.ai/code/session_01QfNTN2yRLNH4qMNFgH9JvM 