### PR TITLE
Add API reference documentation for Torn v2 and TornW3B APIs

### DIFF
--- a/TORN V2 API References.txt
+++ b/TORN V2 API References.txt
@@ -1,0 +1,404 @@
+﻿Torn API
+5.7.1
+OAS 3.1
+/swagger/openapi.json
+* The development of Torn's API v2 is still ongoing.
+* If selections remain unaltered, they will default to the API v1 version.
+* Unlike API v1, API v2 accepts both selections and IDs as path and query parameters.
+* If any discrepancies or errors are found, please submit a bug report on the Torn Forums.
+* In case you're using bots to check for changes on openapi.json file, make sure to specificy a custom user-agent header - CloudFlare sometimes prevents requests from default user-agents.
+Servers
+https://api.torn.com/v2 - This is the base URL
+
+
+
+
+/market/auctionhouse
+Get auction house listings
+Requires public access key.
+Parameters
+Try it out
+Name
+	Description
+	limit
+integer($int32)
+(query)
+	Default value : 20
+	sort
+string
+(query)
+	Sorted by the greatest timestamps
+Available values : DESC, ASC
+--DESCASC
+	from
+integer($int32)
+(query)
+	Timestamp that sets the lower limit for the data returned. Data returned will be after this time
+	to
+integer($int32)
+(query)
+	Timestamp that sets the upper limit for the data returned. Data returned will be up to and including this time
+	timestamp
+string
+(query)
+	Timestamp to bypass cache
+	comment
+string
+(query)
+	Comment for your tool/service/bot/website to be visible in the logs.
+	key
+string
+(query)
+	API key (Public).
+It's not required to use this parameter when passing the API key via the Authorization header.
+	Responses
+Code
+	Description
+	Links
+	200
+	Successful operation
+Media type
+application/json
+Controls Accept header.
+* Example Value
+* Schema
+{
+  "auctionhouse": [
+    {
+      "id": 1073741824,
+      "seller": {
+        "id": 1073741824,
+        "name": "string"
+      },
+      "buyer": {
+        "id": 1073741824,
+        "name": "string"
+      },
+      "timestamp": 1073741824,
+      "price": 1073741824,
+      "bids": 1073741824,
+      "item": {
+        "id": 9007199254740991,
+        "uid": 9007199254740991,
+        "name": "string",
+        "type": "Alcohol"
+      }
+    }
+  ],
+  "_metadata": {
+    "links": {
+      "next": "string",
+      "prev": "string"
+    }
+  }
+}
+	
+
+	
+
+/market/{id}/auctionhouse
+Get specific item auction house listings
+Requires public access key.
+Parameters
+Try it out
+Name
+	Description
+	id *
+integer($int64)
+(path)
+	Item id
+	limit
+integer($int32)
+(query)
+	Default value : 20
+	sort
+string
+(query)
+	Sorted by the greatest timestamps
+Available values : DESC, ASC
+--DESCASC
+	from
+integer($int32)
+(query)
+	Timestamp that sets the lower limit for the data returned. Data returned will be after this time
+	to
+integer($int32)
+(query)
+	Timestamp that sets the upper limit for the data returned. Data returned will be up to and including this time
+	timestamp
+string
+(query)
+	Timestamp to bypass cache
+	comment
+string
+(query)
+	Comment for your tool/service/bot/website to be visible in the logs.
+	key
+string
+(query)
+	API key (Public).
+It's not required to use this parameter when passing the API key via the Authorization header.
+	Responses
+Code
+	Description
+	Links
+	200
+	Successful operation
+Media type
+application/json
+Controls Accept header.
+* Example Value
+* Schema
+{
+  "auctionhouse": [
+    {
+      "id": 1073741824,
+      "seller": {
+        "id": 1073741824,
+        "name": "string"
+      },
+      "buyer": {
+        "id": 1073741824,
+        "name": "string"
+      },
+      "timestamp": 1073741824,
+      "price": 1073741824,
+      "bids": 1073741824,
+      "item": {
+        "id": 9007199254740991,
+        "uid": 9007199254740991,
+        "name": "string",
+        "type": "Alcohol"
+      }
+    }
+  ],
+  "_metadata": {
+    "links": {
+      "next": "string",
+      "prev": "string"
+    }
+  }
+}
+	
+
+	
+
+
+
+/market/{id}/auctionhouselisting
+Get specific item auction house listings
+Requires public access key.
+Parameters
+Try it out
+Name
+	Description
+	id *
+integer($int32)
+(path)
+	Listing id
+	timestamp
+string
+(query)
+	Timestamp to bypass cache
+	comment
+string
+(query)
+	Comment for your tool/service/bot/website to be visible in the logs.
+	key
+string
+(query)
+	API key (Public).
+It's not required to use this parameter when passing the API key via the Authorization header.
+	Responses
+Code
+	Description
+	Links
+	200
+	Successful operation
+Media type
+application/json
+Controls Accept header.
+* Example Value
+* Schema
+{
+  "id": 1073741824,
+  "seller": {
+    "id": 1073741824,
+    "name": "string"
+  },
+  "buyer": {
+    "id": 1073741824,
+    "name": "string"
+  },
+  "timestamp": 1073741824,
+  "price": 1073741824,
+  "bids": 1073741824,
+  "item": {
+    "id": 9007199254740991,
+    "uid": 9007199254740991,
+    "name": "string",
+    "type": "Alcohol"
+  }
+}
+	
+
+	
+
+/market/{id}/itemmarket
+Get item market listings
+Globally cached selection.
+
+Requires public access key.
+Parameters
+Try it out
+Name
+	Description
+	id *
+integer($int64)
+(path)
+	Item id
+	bonus
+string
+(query)
+	Used to filter weapons with a specific bonus.
+Available values : Any, Double, Yellow, Orange, Red, Achilles, Assassinate, Backstab, Berserk, Bleed, Blindfire, Blindside, Bloodlust, Burn, Comeback, Conserve, Cripple, Crusher, Cupid, Deadeye, Deadly, Demoralize, Disarm, Double-edged, Double Tap, Emasculate, Empower, Eviscerate, Execute, Expose, Finale, Focus, Freeze, Frenzy, Fury, Grace, Hazardous, Home run, Irradiate, Lacerate, Motivation, Paralyze, Parry, Penetrate, Plunder, Poison, Powerful, Proficience, Puncture, Quicken, Rage, Revitalize, Roshambo, Shock, Sleep, Slow, Smash, Smurf, Specialist, Spray, Storage, Stricken, Stun, Suppress, Sure Shot, Throttle, Toxin, Warlord, Weaken, Wind-up, Wither
+--AnyDoubleYellowOrangeRedAchillesAssassinateBackstabBerserkBleedBlindfireBlindsideBloodlustBurnComebackConserveCrippleCrusherCupidDeadeyeDeadlyDemoralizeDisarmDouble-edgedDouble TapEmasculateEmpowerEviscerateExecuteExposeFinaleFocusFreezeFrenzyFuryGraceHazardousHome runIrradiateLacerateMotivationParalyzeParryPenetratePlunderPoisonPowerfulProficiencePunctureQuickenRageRevitalizeRoshamboShockSleepSlowSmashSmurfSpecialistSprayStorageStrickenStunSuppressSure ShotThrottleToxinWarlordWeakenWind-upWither
+	limit
+integer($int32)
+(query)
+	Default value : 20
+	offset
+integer($int32)
+(query)
+	Default value : 0
+	timestamp
+string
+(query)
+	Timestamp to bypass cache
+	comment
+string
+(query)
+	Comment for your tool/service/bot/website to be visible in the logs.
+	key
+string
+(query)
+	API key (Public).
+It's not required to use this parameter when passing the API key via the Authorization header.
+	Responses
+Code
+	Description
+	Links
+	200
+	Successful operation
+Media type
+application/json
+Controls Accept header.
+* Example Value
+* Schema
+{
+  "itemmarket": {
+    "item": {
+      "id": 9007199254740991,
+      "name": "string",
+      "type": "string",
+      "average_price": 9007199254740991
+    },
+    "listings": [
+      {
+        "price": 9007199254740991,
+        "amount": 1073741824,
+        "item_details": {
+          "uid": 9007199254740991,
+          "stats": {
+            "damage": 0.1,
+            "accuracy": 0.1,
+            "armor": 0.1,
+            "quality": 0.1
+          },
+          "bonuses": [
+            {
+              "id": 1073741824,
+              "title": "string",
+              "description": "string",
+              "value": 1073741824
+            }
+          ],
+          "rarity": "yellow"
+        }
+      },
+      {
+        "price": 9007199254740991,
+        "amount": 1073741824
+      }
+    ],
+    "cache_timestamp": 1073741824,
+    "cache_delay": 1073741824
+  },
+  "_metadata": {
+    "links": {
+      "next": "string",
+      "prev": "string"
+    }
+  }
+}
+	
+
+	
+
+
+
+
+
+/user/money
+Get your current wealth
+Requires limited access key.
+Parameters
+Try it out
+Name
+	Description
+	timestamp
+string
+(query)
+	Timestamp to bypass cache
+	comment
+string
+(query)
+	Comment for your tool/service/bot/website to be visible in the logs.
+	key
+string
+(query)
+	API key (Limited).
+It's not required to use this parameter when passing the API key via the Authorization header.
+	Responses
+Code
+	Description
+	Links
+	200
+	Successful operation
+Media type
+application/json
+Controls Accept header.
+* Example Value
+* Schema
+{
+  "money": {
+    "points": 9007199254740991,
+    "wallet": 9007199254740991,
+    "company": 9007199254740991,
+    "vault": 9007199254740991,
+    "cayman_bank": 9007199254740991,
+    "city_bank": {
+      "amount": 9007199254740991,
+      "profit": 9007199254740991,
+      "duration": 1073741824,
+      "interest_rate": 0.1,
+      "until": 9007199254740991,
+      "invested_at": 1073741824
+    },
+    "faction": {
+      "money": 9007199254740991,
+      "points": 9007199254740991
+    },
+    "daily_networth": 9007199254740991
+  }
+}

--- a/TornW3B API (weav3r.dev).txt
+++ b/TornW3B API (weav3r.dev).txt
@@ -1,0 +1,330 @@
+﻿TornW3B API
+1.0.0
+OAS 3.0
+/openapi-spec.json
+Welcome
+Access Torn marketplace data, ranked weapons, and dollar bazaar listings.
+Important Info:
+* Responses are cached for 60s
+* No authentication needed
+* Rate limiting of 100 calls/min enforced by Cloudflare
+Support:
+For questions or issues, please reach out in order of preference:
+1. Discord (fastest response)
+2. Forum Thread
+3. Weav3r (DM as last resort)
+API Usage Terms
+Servers
+https://weav3r.dev/api - API Server
+Marketplace
+Access comprehensive marketplace data including all items, their prices, and current bazaar listings. Includes both market prices and real-time bazaar averages.
+GET
+/marketplace
+Get all marketplace items
+Returns all items with their market price, bazaar average, lowest price, and number of bazaars selling
+Parameters
+Try it out
+No parameters
+Responses
+Code
+	Description
+	Links
+	200
+	Successful response
+Media type
+application/json
+Controls Accept header.
+* Example Value
+* Schema
+{
+  "total_count": 0,
+  "items": [
+    {
+      "item_id": 0,
+      "item_name": "string",
+      "market_price": 0,
+      "bazaar_average": 0,
+      "lowest_price": 0,
+      "total_bazaars": 0
+    }
+  ],
+  "response_time_ms": 0
+}
+	No links
+	500
+	Error response
+Media type
+application/json
+* Example Value
+* Schema
+{
+  "error": "string",
+  "message": "string"
+}
+	No links
+	GET
+/marketplace/{itemId}
+Get specific item details
+Returns detailed information about a specific item including all current listings
+Parameters
+Try it out
+Name
+	Description
+	itemId *
+integer
+(path)
+	The item ID
+	Responses
+Code
+	Description
+	Links
+	200
+	Successful response
+Media type
+application/json
+Controls Accept header.
+* Example Value
+* Schema
+{
+  "item_id": 0,
+  "item_name": "string",
+  "market_price": 0,
+  "bazaar_average": 0,
+  "total_listings": 0,
+  "listings": [
+    {
+      "item_id": 0,
+      "player_id": 0,
+      "player_name": "string",
+      "quantity": 0,
+      "price": 0,
+      "content_updated": 0,
+      "last_checked": 0,
+      "content_updated_relative": "string",
+      "last_checked_relative": "string"
+    }
+  ]
+}
+	No links
+	400
+	Error response
+Media type
+application/json
+* Example Value
+* Schema
+{
+  "error": "string",
+  "message": "string"
+}
+	No links
+	404
+	Error response
+Media type
+application/json
+* Example Value
+* Schema
+{
+  "error": "string",
+  "message": "string"
+}
+	No links
+	500
+	Error response
+Media type
+application/json
+* Example Value
+* Schema
+{
+  "error": "string",
+  "message": "string"
+}
+	No links
+	Ranked Weapons
+Search and filter ranked weapons and armor with bonuses. Includes data from both player bazaars and the item market with advanced filtering options.
+GET
+/ranked-weapons
+Search ranked weapons and armor
+Returns ranked weapons/armor with active listings. At least one filter parameter is required.
+Parameters
+Try it out
+Name
+	Description
+	tab
+string
+(query)
+	Filter by weapons or armor
+Available values : weapons, armor
+--weaponsarmor
+	weaponType
+string
+(query)
+	Filter by weapon type
+Available values : melee, primary, secondary, defensive
+--meleeprimarysecondarydefensive
+	weaponName
+string
+(query)
+	Filter by exact weapon name
+	rarity
+string
+(query)
+	Filter by rarity (case-insensitive)
+Available values : yellow, orange, red
+--yelloworangered
+	bonus1
+string
+(query)
+	Filter by first bonus name
+	bonus2
+string
+(query)
+	Filter by second bonus name
+	bonusCount
+string
+(query)
+	Filter by number of bonuses
+Available values : 1, 2
+--12
+	armorPiece
+string
+(query)
+	Filter by armor piece name (for armor tab)
+	armorSet
+string
+(query)
+	Filter by armor set name (for armor tab)
+	minPrice
+number
+(query)
+	Minimum price filter
+	maxPrice
+number
+(query)
+	Maximum price filter
+	minDamage
+number
+(query)
+	Minimum damage filter
+	maxDamage
+number
+(query)
+	Maximum damage filter
+	minAccuracy
+number
+(query)
+	Minimum accuracy filter
+	maxAccuracy
+number
+(query)
+	Maximum accuracy filter
+	minQuality
+number
+(query)
+	Minimum quality filter
+	maxQuality
+number
+(query)
+	Maximum quality filter
+	minBonus1Value
+number
+(query)
+	Minimum value for bonus1
+	maxBonus1Value
+number
+(query)
+	Maximum value for bonus1
+	minBonus2Value
+number
+(query)
+	Minimum value for bonus2
+	maxBonus2Value
+number
+(query)
+	Maximum value for bonus2
+	sortField
+string
+(query)
+	Field to sort by
+Available values : price, damage, accuracy, quality, itemName, weaponType, rarity, bonus1, bonus2
+Default value : price
+--pricedamageaccuracyqualityitemNameweaponTyperaritybonus1bonus2
+	sortDirection
+string
+(query)
+	Sort direction
+Available values : asc, desc
+Default value : asc
+--ascdesc
+	Responses
+Code
+	Description
+	Links
+	200
+	Successful response
+Media type
+application/json
+Controls Accept header.
+* Example Value
+* Schema
+{
+  "total_count": 0,
+  "weapons": [
+    {
+      "uid": "string",
+      "itemId": 0,
+      "itemName": "string",
+      "weaponType": "string",
+      "rarity": "Yellow",
+      "damage": "string",
+      "accuracy": "string",
+      "quality": "string",
+      "bonuses": {
+        "additionalProp1": {
+          "bonus": "string",
+          "value": 0,
+          "description": "string"
+        },
+        "additionalProp2": {
+          "bonus": "string",
+          "value": 0,
+          "description": "string"
+        },
+        "additionalProp3": {
+          "bonus": "string",
+          "value": 0,
+          "description": "string"
+        }
+      },
+      "price": 0,
+      "playerId": 0,
+      "playerName": "string",
+      "quantity": 0,
+      "marketPrice": 0,
+      "lastUpdated": "2026-04-25T23:59:10.527Z",
+      "itemImage": "string"
+    }
+  ],
+  "response_time_ms": 0
+}
+	No links
+	400
+	Error response
+Media type
+application/json
+* Example Value
+* Schema
+{
+  "error": "string",
+  "message": "string"
+}
+	No links
+	500
+	Error response
+Media type
+application/json
+* Example Value
+* Schema
+{
+  "error": "string",
+  "message": "string"
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive API reference documentation for two Torn-related APIs: the official Torn API v2 and the community-maintained TornW3B API.

## Changes
- **TORN V2 API References.txt**: Added complete OpenAPI 3.1 specification documentation for Torn API v2 (version 5.7.1)
  - Market endpoints: `/market/auctionhouse`, `/market/{id}/auctionhouse`, `/market/{id}/auctionhouselisting`, `/market/{id}/itemmarket`
  - User endpoints: `/user/money`
  - Includes parameter definitions, response schemas, and authentication requirements
  - Notes that API v2 is still in development and defaults to v1 if selections are unaltered

- **TornW3B API (weav3r.dev).txt**: Added OpenAPI 3.0 specification documentation for the TornW3B community API (version 1.0.0)
  - Marketplace endpoints: `/marketplace`, `/marketplace/{itemId}`
  - Ranked weapons/armor endpoint: `/ranked-weapons` with extensive filtering and sorting options
  - Includes rate limiting info (100 calls/min), caching details (60s), and support channels
  - No authentication required for public access

## Notable Details
- Both documents include complete endpoint specifications with parameters, response schemas, and example values
- Torn v2 API requires public or limited access keys depending on the endpoint
- TornW3B API is rate-limited by Cloudflare and requires custom user-agent headers for bot usage
- Documentation serves as reference material for API consumers and integration developers

https://claude.ai/code/session_01K5QojE2vgKsKzNuMH2ukua