### PR TITLE
Add manual API key input to settings panel

### DIFF
--- a/torn-rw-auction-advisor-v1.user.js
+++ b/torn-rw-auction-advisor-v1.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn RW Auction Advisor
 // @namespace    estradarpm-rw-auction-advisor
-// @version      1.8.0
+// @version      1.9.0
 // @description  Auction house advisor for Riot and Assault armor — evaluates listings for flip potential
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/amarket.php*
@@ -14,7 +14,7 @@
 (function () {
   'use strict';
 
-  const SCRIPT_VERSION = '1.8.0';
+  const SCRIPT_VERSION = '1.9.0';
   const API_KEY = '###PDA-APIKEY###';
 
   // ── Persistence ────────────────────────────────────────────────────────────
@@ -748,6 +748,13 @@
 
       <!-- Settings pane -->
       <div id="rw-pane-settings" class="rw-pane">
+        <div class="rw-settings-label">API</div>
+
+        <div class="rw-field">
+          <label for="rw-input-apikey">API Key <span style="font-weight:400;color:#4a6070">(only needed if not auto-injected by Torn PDA)</span></label>
+          <input id="rw-input-apikey" class="rw-input" type="password" placeholder="paste key here" style="width:240px">
+        </div>
+
         <div class="rw-settings-label">Pricing</div>
 
         <div class="rw-field">
@@ -783,6 +790,7 @@
   const mugInput        = panel.querySelector('#rw-input-mug');
   const tradeToggle     = panel.querySelector('#rw-toggle-trade');
   const tradeLabel      = panel.querySelector('#rw-toggle-trade-label');
+  const apikeyInput     = panel.querySelector('#rw-input-apikey');
 
   // ── render() ─────────────────────────────────────────────────────────────────
 
@@ -881,6 +889,8 @@
 
   // ── Settings inputs ───────────────────────────────────────────────────────────
 
+  if (Store.get('rw_apikey')) apikeyInput.placeholder = '(key saved)';
+
   profitInput.value = MEM.settings.targetProfitPct;
   mugInput.value    = MEM.settings.mugBufferPct;
   if (MEM.settings.sellViaTrade) {
@@ -902,6 +912,15 @@
     MEM.settings.mugBufferPct = v;
     Store.set(KEYS.MUG_BUFFER_PCT, String(v));
     render();
+  });
+
+  apikeyInput.addEventListener('change', () => {
+    const val = apikeyInput.value.trim();
+    if (val) {
+      Store.set('rw_apikey', val);
+      apikeyInput.value       = '';
+      apikeyInput.placeholder = '(key saved)';
+    }
   });
 
   tradeToggle.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
This update adds the ability for users to manually input their API key through the settings panel, providing an alternative to auto-injection by Torn PDA.

## Key Changes
- **Version bump**: Updated from 1.8.0 to 1.9.0
- **New API settings section**: Added a dedicated "API" section at the top of the settings pane with an API key input field
- **API key persistence**: Implemented storage and retrieval of manually entered API keys using the existing Store utility
- **User feedback**: Added placeholder text that changes to "(key saved)" after a valid key is entered, and displays a helpful note indicating the field is only needed if not auto-injected by Torn PDA
- **Input handling**: Added event listener to process API key input, trim whitespace, store the value, and clear the input field after successful entry

## Implementation Details
- The API key input field is password-type for security
- Keys are stored in the browser's persistent storage via `Store.set('rw_apikey', val)`
- The placeholder text updates dynamically to indicate whether a key has been saved
- Input validation trims whitespace before storing
- The input field is cleared after saving to prevent accidental re-submission

https://claude.ai/code/session_01WARHJM5HfKzXn3WUHLXX3f