### PR TITLE
fix(rw-advisor): strip HTML tags from bonus tooltip text (v1.9.2)

### DIFF
--- a/torn-rw-auction-advisor-v1.user.js
+++ b/torn-rw-auction-advisor-v1.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn RW Auction Advisor
 // @namespace    estradarpm-rw-auction-advisor
-// @version      1.9.1
+// @version      1.9.2
 // @description  Auction house advisor for Riot and Assault armor — evaluates listings for flip potential
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/amarket.php*
@@ -14,7 +14,7 @@
 (function () {
   'use strict';
 
-  const SCRIPT_VERSION = '1.9.1';
+  const SCRIPT_VERSION = '1.9.2';
   const API_KEY = '###PDA-APIKEY###';
 
   // ── Persistence ────────────────────────────────────────────────────────────
@@ -465,8 +465,13 @@
       const bonusSpans = li.querySelectorAll('.iconsbonuses span');
       let bonusType = null;
       if (bonusSpans.length) {
-        // Prefer the title attribute (full tooltip text); fall back to visible text
-        bonusType = (bonusSpans[0].getAttribute('title') ?? bonusSpans[0].textContent).trim() || null;
+        // title attribute often contains HTML markup (<b>, <br>) — strip it to plain text
+        const rawBonus = (bonusSpans[0].getAttribute('title') ?? bonusSpans[0].textContent).trim();
+        bonusType = rawBonus
+          .replace(/<br\s*\/?>/gi, ' ')
+          .replace(/<[^>]*>/g, '')
+          .replace(/\s+/g, ' ')
+          .trim() || null;
       }
 
       // ── Quality % and bonus % via full-text regex ────────────────────────


### PR DESCRIPTION
Torn's span title attributes contain markup like <b>Impregnable</b><br>25%. Storing that raw string then passing it through escHtml() caused the tags to render as visible text in the Bonus column. Now strip <br> → space, then strip all remaining tags, and collapse whitespace at parse time so bonusType always contains clean plain text.

https://claude.ai/code/session_01WARHJM5HfKzXn3WUHLXX3f