### PR TITLE
v1.15.8: Fix syntax error (duplicate const tier) that broke the tool …

### DIFF
--- a/torn-rw-auction-advisor-v1.user.js
+++ b/torn-rw-auction-advisor-v1.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn RW Auction Advisor
 // @namespace    estradarpm-rw-auction-advisor
-// @version      1.15.7
+// @version      1.15.8
 // @description  Auction house advisor for Riot and Assault armor — evaluates listings for flip potential
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/amarket.php*
@@ -15,7 +15,7 @@
 (function () {
   'use strict';
 
-  const SCRIPT_VERSION = '1.15.7';
+  const SCRIPT_VERSION = '1.15.8';
   const API_KEY = '###PDA-APIKEY###';
 
   // ── Persistence ────────────────────────────────────────────────────────────
@@ -1267,13 +1267,14 @@
         const up = fmtM(l.interpUpper?.price);
         compCellInner = `${fmtM(refPrice)}&thinsp;<span style="color:#f0a040;font-size:10px;font-weight:700" title="Interpolated between ${lq}% qual (${lp}) and ${uq}% qual (${up})">interp</span>`;
       } else if (compSource === 'single-bound') {
-        const bound = l.interpLower;
-        const tip   = `Only lower quality bound (${bound?.quality?.toFixed(1)}% at ${fmtM(bound?.price)}) — this piece is higher quality than all comps; price is a floor`;
-        compCellInner = `≥${fmtM(refPrice)}&thinsp;<span style="color:#f0a040;font-size:10px;font-weight:700" title="${tip}">floor</span>`;
-      } else if (compSource === 'base-fallback') {
-        const uq = l.interpUpper?.quality?.toFixed(1) ?? '?';
-        const up = fmtM(l.interpUpper?.price);
-        compCellInner = `${fmtM(refPrice)}&thinsp;<span style="color:#f0a040;font-size:10px;font-weight:700" title="All market comps are higher quality (cheapest: ${uq}% at ${up}) — used base-stat price as reference; piece is low-quality, valued near base">⌊base</span>`;
+        const isLower = l.interpLower != null;
+        const bound   = isLower ? l.interpLower : l.interpUpper;
+        const dir     = isLower ? '≥' : '≤';
+        const side    = isLower ? 'floor' : 'ceil';
+        const tip     = isLower
+          ? `Only lower quality bound found (${bound?.quality?.toFixed(1)}% at ${fmtM(bound?.price)}) — target quality exceeds all comps`
+          : `Only upper quality bound found (${bound?.quality?.toFixed(1)}% at ${fmtM(bound?.price)}) — target quality below all comps`;
+        compCellInner = `${dir}${fmtM(refPrice)}&thinsp;<span style="color:#f0a040;font-size:10px;font-weight:700" title="${tip}">${side}</span>`;
       } else {
         compCellInner = `${fmtM(refPrice)}&thinsp;<span style="color:#f0a040;font-size:10px;font-weight:700" title="No quality data in comp listings — cheapest bonus-matched price only">~</span>`;
       }
@@ -1291,7 +1292,6 @@
       const offerRiskFlag = !bbFloorActive && !kingCapActive && compSource !== 'quality-match'
                             && histMedian != null && maxOffer != null && maxOffer > histMedian;
 
-      const tier          = l.tier ?? 'base';
       const capColor      = tier === 'exceptional' ? '#e060e0' : '#60a0f0';
       const capMult       = tier === 'exceptional' ? EXCEPTIONAL_MULTIPLIER : HQ_MULTIPLIER;
       const offerBadge    = kingCapActive
@@ -1588,16 +1588,8 @@
           }
         }
         if (refPrice == null) {
-          // Upper-bound-only case: all comps are higher quality than the target piece.
-          // Those inflated prices cannot be used — a 5% quality piece is not worth
-          // what a 30% quality listing says. Use base-stat comp as the price floor.
-          if (interpUpper != null && interpLower == null) {
-            const imBase  = getItemMarketComp(itemId, baseBonusPct, null, { strict: true });
-            const w3bBase = getTornW3BComp(listing.name, listing.armorSet, listing.rarity, baseBonusPct, null, { strict: true });
-            const bsp = Math.min(imBase?.price ?? Infinity, w3bBase?.price ?? Infinity);
-            if (bsp < Infinity) { refPrice = bsp; compSource = 'base-fallback'; }
-          }
-          if (refPrice == null) { refPrice = Math.min(imPrice, w3bPrice); compSource = 'bonus-only'; }
+          refPrice   = Math.min(imPrice, w3bPrice);
+          compSource = 'bonus-only';
         }
       } else {
         refPrice   = Math.min(imPrice, w3bPrice);


### PR DESCRIPTION
…entirely

const tier was declared twice in the same render() block scope — once for the tier badge (line 1245) and again for the cap badge section. The second declaration caused an 'Identifier already declared' error that prevented the script from loading at all, making the panel invisible on amarket.php.

Also reverts the base-fallback refPrice logic from v1.15.7 which was producing max offers (~50M) below typical auction clearing prices (~69M), making it impossible to win any bids. The upper-bound-only interpolation case now falls back to bonus-only comp (cheapest listing for the bonus level) as it did before — the single-bound 'ceil' badge indicates when market data only has higher-quality comps available.

https://claude.ai/code/session_018vMhtcuqYco7QpacBsXmCU