### PR TITLE
v1.15.9: Cap refPrice when a cheaper better-quality listing exists

### DIFF
--- a/torn-rw-auction-advisor-v1.user.js
+++ b/torn-rw-auction-advisor-v1.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn RW Auction Advisor
 // @namespace    estradarpm-rw-auction-advisor
-// @version      1.15.8
+// @version      1.15.9
 // @description  Auction house advisor for Riot and Assault armor — evaluates listings for flip potential
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/amarket.php*
@@ -15,7 +15,7 @@
 (function () {
   'use strict';
 
-  const SCRIPT_VERSION = '1.15.8';
+  const SCRIPT_VERSION = '1.15.9';
   const API_KEY = '###PDA-APIKEY###';
 
   // ── Persistence ────────────────────────────────────────────────────────────
@@ -1594,6 +1594,25 @@
       } else {
         refPrice   = Math.min(imPrice, w3bPrice);
         compSource = 'bonus-only';
+      }
+
+      // ── Market ceiling: prevent overpriced outlier bazaar listings from inflating refPrice ──
+      // If a bonus-matched listing exists with quality >= target piece AND price < refPrice,
+      // our piece cannot realistically sell for more (buyers will take the better piece instead).
+      if (refPrice != null && listing.qualityPct != null) {
+        const allPoints = [
+          ...(imComp?.bonusMatchedPoints  ?? []),
+          ...(w3bComp?.bonusMatchedPoints ?? []),
+        ];
+        const betterCheaper = allPoints
+          .filter(p => p.quality >= listing.qualityPct && p.price < refPrice)
+          .sort((a, b) => a.price - b.price)[0];
+        if (betterCheaper) {
+          refPrice   = betterCheaper.price;
+          compSource = 'bonus-only';
+          interpLower = null;
+          interpUpper = null;
+        }
       }
 
       // ── King's cap for HQ/exceptional (ceiling on maxOffer, not on refPrice) ─


### PR DESCRIPTION
Root cause of 124.4M comp on a Q9.8%/B30% Dune Boots worth ~73-76M: TornW3B aggregates ALL bazaar listings including overpriced ones. An outlier low-quality listing (e.g. Q8%@130M from a mispriced bazaar) becomes the nearest lower-quality bracket. Upper bracket = Q24.28%@73M. Interpolation between 130M and 73M lands at ~124M despite the real market being 73-76M.

Fix: after computing refPrice from any source, scan all bonus-matched quality points. If any listing has quality >= target AND price < refPrice, that listing is a better piece available for less — buyers would prefer it, so our piece cannot realistically sell for more. Cap refPrice there.

For Q9.8%/B30% Dune Boots: cheapest listing with quality >= 9.8% is Q24.28%@73M. refPrice drops from 124.4M to 73M. With BB floor at 75.6M, max offer = 75.6M (floor governs), correctly showing thin margin at 71M bid.

For high-quality pieces where all comps are lower quality, no cap fires — the target piece is better than everything available and commands a premium.

https://claude.ai/code/session_018vMhtcuqYco7QpacBsXmCU