### PR TITLE
v1.16.0: weighted multi-cache BB rate from all 5 combat caches

### DIFF
--- a/torn-rw-auction-advisor-v1.user.js
+++ b/torn-rw-auction-advisor-v1.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn RW Auction Advisor
 // @namespace    estradarpm-rw-auction-advisor
-// @version      1.15.9
+// @version      1.16.0
 // @description  Auction house advisor for Riot and Assault armor — evaluates listings for flip potential
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/amarket.php*
@@ -15,7 +15,7 @@
 (function () {
   'use strict';
 
-  const SCRIPT_VERSION = '1.15.9';
+  const SCRIPT_VERSION = '1.16.0';
   const API_KEY = '###PDA-APIKEY###';
 
   // ── Persistence ────────────────────────────────────────────────────────────
@@ -31,7 +31,7 @@
     MUG_BUFFER_PCT     : 'rw_mugBufferPct',
     SELL_VIA_TRADE     : 'rw_sellViaTrade',
     BB_RATE            : 'rw_bbRate',
-    CACHE_ITEM_ID      : 'rw_cacheItemId',
+    CACHE_ITEM_IDS     : 'rw_cacheItemIds',
     ARMOR_ITEM_IDS     : 'rw_armorItemIds',
     COLLAPSED          : 'rw_collapsed',
     POSITION           : 'rw_position',
@@ -62,8 +62,8 @@
     // { [key]: weapons[] } where weapons[] is the full TornW3B response array
     tornw3bComps: {},
 
-    // Current $/BB rate derived from small arm cache price
-    // { rate, cachePrice, fetchedAt }
+    // Weighted $/BB rate from all 5 combat caches
+    // { rate, cachePrices: { name: price }, fetchedAt }
     bbRate: (() => {
       try { return JSON.parse(Store.get(KEYS.BB_RATE)) || null; } catch { return null; }
     })(),
@@ -436,7 +436,7 @@
     if (err.code === 2 || err.code === 13) {
       // Incorrect key (2) or key owner banned (13) — stop using it
       Store.remove(KEYS.BB_RATE);
-      Store.remove(KEYS.CACHE_ITEM_ID);
+      Store.remove(KEYS.CACHE_ITEM_IDS);
     }
   }
 
@@ -708,53 +708,90 @@
     return { price, avgQuality, qualityMatched, bonusMatchedPoints };
   }
 
+  // All 5 combat caches. Each costs 20 BB — same divisor for all.
+  const COMBAT_CACHES = [
+    'Small Arms Cache',
+    'Melee Cache',
+    'Medium Arms Cache',
+    'Armor Cache',
+    'Heavy Arms Cache',
+  ];
+  const BB_PER_CACHE = 20;
+
   /**
-   * Fetches the current $/BB rate by looking up the cheapest Small Arms Cache
-   * listing on the item market. Resolves the cache item ID at runtime via the
-   * Torn v1 items catalog and caches it in localStorage to avoid repeat lookups.
+   * Fetches the weighted $/BB rate from all 5 combat caches.
+   *
+   * Weight formula: weight_i = (1/price_i) / sum(1/price_j)
+   * Cheaper caches automatically receive higher weight, making the
+   * resulting rate more conservative (pulled toward the cheapest cache).
+   *
+   * Item IDs are resolved once from the Torn catalog and persisted as a
+   * name→id map in localStorage. Only missing IDs trigger a catalog fetch.
    *
    * Stores result in MEM.bbRate and persists to localStorage.
-   * @returns {Promise<{rate, cachePrice, fetchedAt}|null>}
+   * @returns {Promise<{rate, cachePrices, fetchedAt}|null>}
    */
   async function fetchBBRate() {
     const key = getApiKey();
     if (!key) { MEM.fetchError = 'No API key — enter one in Settings'; return null; }
 
     try {
-      // Resolve Small Arms Cache item ID (cached after first lookup)
-      let cacheItemId = parseInt(Store.get(KEYS.CACHE_ITEM_ID), 10) || null;
+      // Load persisted cache ID map; resolve any missing IDs via catalog
+      let cacheItemIds = (() => {
+        try { return JSON.parse(Store.get(KEYS.CACHE_ITEM_IDS)) || {}; } catch { return {}; }
+      })();
 
-      if (!cacheItemId) {
-        const catalogUrl  = `https://api.torn.com/torn/?selections=items&key=${key}&comment=rw-advisor`;
-        const catalogData = await apiFetch(catalogUrl);
+      const missing = COMBAT_CACHES.filter(name => !cacheItemIds[name]);
+      if (missing.length) {
+        const catalogData = await apiFetch(
+          `https://api.torn.com/torn/?selections=items&key=${key}&comment=rw-advisor`
+        );
         if (catalogData.error) { handleApiError(catalogData.error); return null; }
 
-        const entry = Object.entries(catalogData.items || {}).find(
-          ([, item]) => item.name?.toLowerCase() === 'small arms cache'
-        );
-        if (!entry) {
-          MEM.fetchError = 'Small Arms Cache not found in item catalog';
+        for (const [id, item] of Object.entries(catalogData.items ?? {})) {
+          if (COMBAT_CACHES.includes(item.name)) {
+            cacheItemIds[item.name] = parseInt(id, 10);
+          }
+        }
+
+        const stillMissing = COMBAT_CACHES.filter(name => !cacheItemIds[name]);
+        if (stillMissing.length) {
+          MEM.fetchError = `Cache IDs not found: ${stillMissing.join(', ')}`;
           return null;
         }
 
-        cacheItemId = parseInt(entry[0], 10);
-        Store.set(KEYS.CACHE_ITEM_ID, String(cacheItemId));
+        Store.set(KEYS.CACHE_ITEM_IDS, JSON.stringify(cacheItemIds));
       }
 
-      // Fetch the cheapest listing for the cache item
-      const marketUrl  = `https://api.torn.com/v2/market/${cacheItemId}/itemmarket?limit=1&key=${key}&comment=rw-advisor`;
-      const marketData = await apiFetch(marketUrl);
+      // Fetch cheapest listing for each cache in parallel
+      const results = await Promise.all(
+        COMBAT_CACHES.map(async name => {
+          const id   = cacheItemIds[name];
+          const data = await apiFetch(
+            `https://api.torn.com/v2/market/${id}/itemmarket?limit=1&key=${key}&comment=rw-advisor`
+          );
+          if (data.error) { handleApiError(data.error); return null; }
+          const price = data.itemmarket?.listings?.[0]?.price ?? null;
+          return { name, price };
+        })
+      );
 
-      if (marketData.error) { handleApiError(marketData.error); return null; }
-
-      const listings = marketData.itemmarket?.listings;
-      if (!listings?.length) {
-        MEM.fetchError = 'No listings found for Small Arms Cache';
+      // Require at least one valid price to proceed
+      const valid = results.filter(r => r?.price != null && r.price > 0);
+      if (!valid.length) {
+        MEM.fetchError = 'No cache listings found for BB rate calculation';
         return null;
       }
 
-      const cachePrice = listings[0].price;
-      const bbRateData = { rate: cachePrice / 20, cachePrice, fetchedAt: Date.now() };
+      // Inverse-price weighted average: cheaper cache → higher weight
+      const invSum = valid.reduce((s, r) => s + 1 / r.price, 0);
+      const weightedRate = valid.reduce((s, r) => {
+        const weight = (1 / r.price) / invSum;
+        return s + weight * (r.price / BB_PER_CACHE);
+      }, 0);
+
+      const cachePrices = Object.fromEntries(valid.map(r => [r.name, r.price]));
+      const bbRateData  = { rate: weightedRate, cachePrices, fetchedAt: Date.now() };
       MEM.bbRate = bbRateData;
       Store.set(KEYS.BB_RATE, JSON.stringify(bbRateData));
       return bbRateData;


### PR DESCRIPTION
Replace single Small Arms Cache price with inverse-price weighted average across all 5 combat caches (Small Arms, Melee, Medium Arms, Armor, Heavy Arms). Cheaper caches receive proportionally higher weight, pulling the BB rate toward the cheapest market floor.

Item IDs resolved from Torn catalog on first run and persisted as a name→id map (rw_cacheItemIds). All 5 prices fetched in parallel.

https://claude.ai/code/session_018vMhtcuqYco7QpacBsXmCU