### PR TITLE
Add auto-memory system: SessionStart hook + memory.md template

### DIFF
--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -1,0 +1,23 @@
+# Session Memory — Torn Scripts
+
+_Last updated: (not yet written)_
+
+## Current WIP
+<!-- What is actively being worked on right now -->
+(none)
+
+## Recent Decisions
+<!-- Key choices made and the reasoning behind them -->
+(none)
+
+## Open Questions
+<!-- Unresolved issues, blockers, or things to revisit -->
+(none)
+
+## Key File Locations
+<!-- Important paths, line numbers, or symbols discovered -->
+(none)
+
+## Next Steps
+<!-- Concrete next actions to pick up at the start of the next session -->
+(none)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -f .claude/memory.md ] && echo '=== SESSION MEMORY ===' && cat .claude/memory.md && echo '=== END SESSION MEMORY ===' || echo '[No session memory yet — first session in this repo]'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,19 @@
 # Torn Scripts — Claude Guidelines
 
+## Session Memory
+
+At the **start of every session**, immediately read `.claude/memory.md`. The SessionStart hook will output its contents automatically, but if for any reason it wasn't shown, read the file explicitly before doing anything else.
+
+At the **end of any session where meaningful work was done**, update `.claude/memory.md` with:
+- What is currently WIP (be specific: file names, function names, line numbers)
+- Key decisions made this session and the reasoning
+- Any open questions or blockers
+- Concrete next steps for the following session
+
+Keep the file under 300 lines. Replace stale entries rather than appending indefinitely. Use the date in the `_Last updated_` line.
+
+---
+
 ## Repository Purpose
 
 Personal collection of scripts for the browser game **Torn City** (torn.com). Scripts range from Tampermonkey/Greasemonkey userscripts (`.user.js`) to standalone tools and utilities. All scripts are Torn-specific.


### PR DESCRIPTION
Adds .claude/settings.json with a SessionStart hook that outputs
.claude/memory.md at the top of every session automatically. Adds
.claude/memory.md as a structured template for tracking WIP, decisions,
open questions, and next steps across sessions. Updates CLAUDE.md with
explicit instructions to read memory at session start and update it at
session end with meaningful progress.

https://claude.ai/code/session_01Df9XxdcUCsC9imEVNcLnSJ