### PR TITLE
feat(ledger): Step A — result capture dropdown (v1.22.0)

### DIFF
--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -1,16 +1,16 @@
 # Claude Session Memory — Torn Scripts
 
-_Last updated: 2026-04-27_
+_Last updated: 2026-04-27 (Step A done)_
 
 ---
 
 ## Current WIP
 
 **File:** `torn-rw-auction-advisor-v1.user.js`
-**Branch:** `claude/inline-auction-advisor-MxQCI` → open PR → `main`
-**Version:** `1.21.1`
+**Branch:** `claude/rw-auction-tool-next-step-A2b3A`
+**Version:** `1.22.0`
 
-### All steps complete (Steps 1–6)
+### Completed steps
 
 | Step | Description | Version |
 |------|-------------|---------|
@@ -20,8 +20,9 @@ _Last updated: 2026-04-27_
 | 4 | Settings modal polish — Data Sources section, API key mask/reveal, error feedback | 1.20.0 |
 | 5 | Ledger framework scaffold — Log button, sidebar panel, localStorage persistence | 1.21.0 |
 | 6 | CLAUDE.md documentation + memory.md final update | 1.21.1 |
+| **A** | **Result capture dropdown — —/Won/Lost/Passed per ledger row; delegated change listener persists to localStorage** | **1.22.0** |
 
-### Key function locations (final)
+### Key function locations
 
 | Symbol | Line (approx) | Notes |
 |--------|---------------|-------|
@@ -29,12 +30,13 @@ _Last updated: 2026-04-27_
 | `injectAdvisoryStrip(listing)` | ~1340 | Builds `.rwa-strip`, wires all 4 buttons |
 | `buildContextPanel(listing)` | ~1500 | Returns `.rwa-context` div with 5 metric rows |
 | `buildCompsPanel(listing)` | ~1550 | Returns `.rwa-comps` 2-column panel with `_refreshCol` / `_isStale` |
-| `logListing(listing)` | ~1640 | Snapshots listing into MEM.ledger, persists |
-| `renderLedger()` | ~1660 | Rebuilds ledger table from MEM.ledger |
-| `refreshDataSources()` | ~1690 | Populates Data Sources section in settings modal |
-| `renderInline()` | ~1630 | Re-runs injectAdvisoryStrip for all listings |
-| `init()` | ~1750 | Main data pipeline: parse → BB rate → comps → enrich → render |
-| `safeInit()` | ~1780 | MutationObserver debounce wrapper with 30s cooldown |
+| `logListing(listing)` | ~1645 | Snapshots listing into MEM.ledger, persists |
+| `renderLedger()` | ~1665 | Rebuilds ledger table from MEM.ledger; renders result dropdown per row |
+| `refreshDataSources()` | ~1700 | Populates Data Sources section in settings modal |
+| `renderInline()` | ~1635 | Re-runs injectAdvisoryStrip for all listings |
+| `init()` | ~1760 | Main data pipeline: parse → BB rate → comps → enrich → render |
+| `safeInit()` | ~1790 | MutationObserver debounce wrapper with 30s cooldown |
+| ledgerBody change listener | ~1308 | Delegated handler for `.rwa-result-select`; updates entry.result + persists |
 
 ### DOM structure (final)
 
@@ -75,24 +77,24 @@ _Last updated: 2026-04-27_
 | Function declarations (not const arrows) for render/build fns | Hoisted within IIFE — safe to reference from event handlers defined earlier |
 | `buildCompsPanel._refreshCol()` / `._isStale()` as panel-attached methods | Keeps fetch logic co-located with the panel it modifies; avoids closure over strip |
 | Step size limit: ~50–80 lines per edit | Prevents API stream idle timeout; each sub-step is a self-contained commit |
-| Ledger result column left as `—` placeholder | Future Step A; structure complete, no partial logic committed |
+| Delegated `change` listener on `ledgerBody` for result select | Container persists across `innerHTML` resets — no need to re-attach on each renderLedger call |
+| `sel.value || null` for result storage | Empty string (—) stored as null for consistent `!e.result` checks |
 
 ---
 
 ## Open Questions / Blockers
 
-- None. All 6 steps are committed and pushed.
-- Future ledger features (Steps A–E) are documented in `CLAUDE.md` under "Future ledger steps".
+- None. Step A is committed and pushed.
+- Future ledger features (Steps B–E) are documented in `CLAUDE.md` under "Future ledger steps".
 
 ---
 
 ## Concrete Next Steps
 
-The inline advisor is feature-complete at v1.21.1. Next actions:
-
-1. **Merge the open PR** into `main`
-2. **Future ledger work** — see CLAUDE.md "Future ledger steps" for Steps A–E (result capture, P&L, CSV export, filtering, summary stats)
-3. Each future step follows the same iterative sub-step pattern with user confirmation before starting
+1. **Step B — P&L calculation (→ 1.23.0)**: For `result === 'Won'` rows, add an "Actual sell price" input. On blur/enter compute `actualNet = sellPrice × (1 − marketFee) × (1 − mugBuffer) − entry.currentBid`. Persist `actualSellPrice` and `actualNet` to the entry schema.
+2. **Step C — CSV export (→ 1.24.0)**
+3. **Step D — Filtering (→ 1.25.0)**
+4. **Step E — Summary stats (→ 1.26.0)**
 
 ---
 

--- a/torn-rw-auction-advisor-v1.user.js
+++ b/torn-rw-auction-advisor-v1.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn RW Auction Advisor
 // @namespace    estradarpm-rw-auction-advisor
-// @version      1.21.1
+// @version      1.22.0
 // @description  Auction house advisor for Riot and Assault armor — evaluates listings for flip potential
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/amarket.php*
@@ -15,7 +15,7 @@
 (function () {
   'use strict';
 
-  const SCRIPT_VERSION = '1.21.1';
+  const SCRIPT_VERSION = '1.22.0';
   const API_KEY = '###PDA-APIKEY###';
 
   // ── Persistence ────────────────────────────────────────────────────────────
@@ -1159,6 +1159,8 @@
       top: 0;
     }
     .rwa-ledger-table td { border-bottom: 1px solid #0c1620; color: #c0d0c8; padding: 5px 8px; vertical-align: top; white-space: nowrap; }
+    .rwa-result-select { background: #0c1620; border: 1px solid #1e3040; border-radius: 3px; color: #c0d0c8; font-size: 11px; padding: 1px 4px; cursor: pointer; }
+    .rwa-result-select option { background: #0c1620; }
     .rwa-ledger-table tr:last-child td { border-bottom: none; }
 
     /* ── Advisory strip (injected into each auction li) ── */
@@ -1302,6 +1304,16 @@
   const rwaGearBtn    = document.getElementById('rwa-gear-btn');
   const rwaErrorToast = document.getElementById('rwa-error-toast');
   const ledgerBody    = document.getElementById('rwa-ledger-body');
+
+  ledgerBody.addEventListener('change', ev => {
+    const sel = ev.target.closest('.rwa-result-select');
+    if (!sel) return;
+    const id = parseInt(sel.dataset.entryId, 10);
+    const entry = MEM.ledger.find(x => x.id === id);
+    if (!entry) return;
+    entry.result = sel.value || null;
+    Store.set(KEYS.LEDGER, JSON.stringify(MEM.ledger));
+  });
 
   function showError(msg) {
     if (!msg) { rwaErrorToast.classList.remove('rwa-visible'); return; }
@@ -1667,7 +1679,12 @@
       <td>${escHtml(fmtM(e.currentBid))}</td>
       <td>${escHtml(fmtM(e.maxOffer))}</td>
       <td>${e.roi != null ? e.roi.toFixed(1) + '%' : '—'}</td>
-      <td style="color:#2a5040">—</td>
+      <td><select class="rwa-result-select" data-entry-id="${e.id}">
+        <option value="" ${!e.result ? 'selected' : ''}>—</option>
+        <option value="Won"    ${e.result === 'Won'    ? 'selected' : ''}>Won</option>
+        <option value="Lost"   ${e.result === 'Lost'   ? 'selected' : ''}>Lost</option>
+        <option value="Passed" ${e.result === 'Passed' ? 'selected' : ''}>Passed</option>
+      </select></td>
     </tr>`).join('');
     ledgerBody.innerHTML = `<table class="rwa-ledger-table">
       <thead><tr>


### PR DESCRIPTION
Replace static — placeholder in the Result column with a <select>
dropdown (—/Won/Lost/Passed) per ledger row. A single delegated change
listener on ledgerBody updates entry.result in MEM.ledger and persists
to localStorage without requiring a full re-render.

https://claude.ai/code/session_01VfVSmxUhiz86YQ3Dn3LUH7