### PR TITLE
fix(quality): correct quality parse regex and remove misleading avgQuality fallback (v1.26.1)

### DIFF
--- a/torn-rw-auction-advisor-v1.user.js
+++ b/torn-rw-auction-advisor-v1.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn RW Auction Advisor
 // @namespace    estradarpm-rw-auction-advisor
-// @version      1.26.0
+// @version      1.26.1
 // @description  Auction house advisor for Riot and Assault armor — evaluates listings for flip potential
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/amarket.php*
@@ -15,7 +15,7 @@
 (function () {
   'use strict';
 
-  const SCRIPT_VERSION = '1.26.0';
+  const SCRIPT_VERSION = '1.26.1';
   const API_KEY = '###PDA-APIKEY###';
 
   // ── Persistence ────────────────────────────────────────────────────────────
@@ -817,7 +817,7 @@
   const ARMOR_PIECES  = ['Helmet', 'Body', 'Vest', 'Mask', 'Pants', 'Gloves', 'Boots'];
   const RARITY_GLOWS  = ['red', 'orange', 'yellow'];
 
-  const RE_QUALITY = /[Qq]uality[:\s]+([0-9]+(?:\.[0-9]+)?)\s*%/;
+  const RE_QUALITY = /[Qq]uality[:\s]*([0-9]+(?:\.[0-9]+)?)\s*%/;
   const RE_PRICE   = /\$\s*([0-9,]+)/;
 
   /**
@@ -2084,7 +2084,6 @@
       const anyQualityMatched = imQM || w3bQM;
 
       const winner = imPrice <= w3bPrice ? imComp : w3bComp;
-      if (listing.qualityPct == null) listing.qualityPct = winner?.avgQuality ?? null;
 
       let refPrice    = null;
       let compSource  = 'bonus-only';


### PR DESCRIPTION
RE_QUALITY used [:\s]+ (one-or-more) but Torn renders the Quality label and
value in adjacent spans with no text separator, so li.textContent yields
"Quality4.06%" with nothing between them. Changed to [:\s]* (zero-or-more)
so the regex matches even when there is no separator character.

Also removed the line that set listing.qualityPct = winner.avgQuality when
quality could not be parsed from the DOM. That assignment ran before the
refPrice branching logic, silently switching from the correct bonus-only path
to the interpolation path with a wrong quality target (~23% average of comps
instead of the actual 4.06%). It also corrupted the context panel display
(Q23% instead of — or Q4%) and polluted the ledger. Now qualityPct stays null
when the DOM does not expose it, and the pricing correctly falls through to the
bonus-only branch.

https://claude.ai/code/session_01GGtaQ4rcKrQ5NpmKuTv8sV