### PR TITLE
feat(advisor): dynamic floor pricing algorithm (v1.29.0)

### DIFF
--- a/.claude/memory.md
+++ b/.claude/memory.md
@@ -1,14 +1,14 @@
 # Claude Session Memory — Torn Scripts
 
-_Last updated: 2026-04-27 (PRD filed; ready to begin v1.29.0)_
+_Last updated: 2026-04-27 (v1.29.0 implemented, PR pending)_
 
 ---
 
 ## Current WIP
 
 **File:** `torn-rw-auction-advisor-v1.user.js`
-**Branch:** `claude/clever-heyrovsky-8ce863` (current worktree)
-**Version:** `1.28.3` (live on main)
+**Branch:** `claude/nifty-yalow-f26e10` (current worktree)
+**Version:** `1.29.0` (implemented this session, not yet merged to main)
 
 ### Completed steps
 
@@ -28,86 +28,74 @@ _Last updated: 2026-04-27 (PRD filed; ready to begin v1.29.0)_
 | F | Quality debug: RE_QUALITY/RE_ARMOR fixed for live DOM | 1.26.1–1.26.4 |
 | G | Settings persistence fix | 1.27.0 |
 | H1–H5 | Comp panel: median-window, THIS row, price-sorted, dual markers, price-window | 1.27.1–1.28.3 |
+| I | Dynamic floor pricing: detectFloorCluster, classifyListing, floor flip display, gap interpolation, min floor profit setting | 1.29.0 |
 
 ---
 
-## Key Decisions Made This Session
+## Key Decisions Made This Session (v1.29.0)
 
-### PRD filed as GitHub issue #158
-Full PRD at `docs/prd-steps-i-through-l.md` and https://github.com/EstradaRPM/Torn-scripts/issues/158
+### Algorithm implemented as PRD specified
 
-### Dynamic pricing algorithm (replaces hardcoded Steps I + J)
+- **`detectFloorCluster(comps, threshold=0.12)`** — pure function. Cluster = listings within 12% of cheapest. Returns `{ floorPrice, bestQualityPct, bestBonusPct, clusterSize, isValid }`. `isValid` = clusterSize >= 3.
 
-The grill-me session fundamentally changed the approach. No hardcoded quality/bonus thresholds. Classification is fully dynamic from live comp data.
+- **`classifyListing(listing, floorCluster, allComps)`** — pure function. Returns 'floor'|'gap'|'hq'|'sparse'. Gap = beats floor cluster but no premium comps within 20pp quality / 4pp bonus. HQ = beats floor and near premium comps exist.
 
-**The algorithm:**
-1. Fetch all comps (item market + bazaar) for this piece type
-2. Sort by price ascending, detect **floor cluster** — listings within 10–15% of cheapest
-3. Identify **best piece in floor cluster** (highest qualityPct AND bonusPct available at floor)
-4. Classify current listing:
+- **`calcFloorFlipMaxBid(floorPrice, minFloorProfit, marketFee)`** — pure function. `maxBid = floorPrice - minFloorProfit`. `bazaarNet = minFloorProfit` (no fee). `marketNet = round(floorPrice * 0.95) - maxBid`.
 
-| Scenario | Classification |
-|----------|---------------|
-| quality AND bonus ≤ floor cluster best | `floor` — quick flip |
-| beats floor cluster, comps exist above | `hq` — Step H median comp pricing |
-| beats floor cluster, no close comps above | `gap` — interpolate toward floor anchor (~25–30%) |
-| fewer than 3 comps total | `sparse` — show comps, no auto recommendation |
-| max offer > 2× BB floor | any tier — add ⚠ 2× BB warning badge |
+- **`interpolateGapPrice(floorAnchor, premiumAnchor, lean=0.27)`** — pure function. Leans 27% toward floor anchor (not midpoint). Fallback premiumAnchor = `floorPrice * 2.0` when no premium comps exist.
 
-**Floor flip display:**
-- Shows bazaar net and market net separately
-- Max bid = `floor_price − minFloorProfit` (one setting, pre-fee, absolute $)
-- Mug buffer defaults 0% for floor flips (open question, flagged)
-- Target profit % ignored entirely for floor pieces
+- **`buildNormalizedComps(listing)`** — helper. Gathers all raw item-market + W3B comps for this item (by itemId), normalized to `{ price, qualityPct, bonusPct }`. Called early in `enrichListingsFromMarketData` loop before the `continue` check.
 
-**Exceptional tier:** Not a separate formula — HQ logic + 2× BB warning badge only
+### Classification stored on listing
 
-**Gap interpolation:** Lean 25–30% toward floor anchor (not midpoint). Validated by real trading: gap pieces priced close to floor sell faster than midpoint-priced ones.
+`enrichListingsFromMarketData` now sets:
+- `listing.floorCluster` — full cluster object (even when `isValid=false`)
+- `listing.classification` — 'floor'|'gap'|'hq'|'sparse'
+- `listing.gapPremiumAnchor` — cheapest comp above floor cluster (null for non-gap)
 
-### New setting: Min floor profit
-Single absolute dollar amount (e.g. $5M). Stored as `KEYS.MIN_FLOOR_PROFIT`. Appears in settings modal alongside existing profit % and mug buffer.
+The floor cluster detection runs BEFORE the `continue` (no-comps) check so every listing gets classified.
 
-### Ubiquitous language glossary
-Written to `UBIQUITOUS_LANGUAGE.md`. Defer standardisation cleanup until after Step J (v1.30.0) lands — new pricing code will introduce base/HQ/exceptional tier terms naturally.
+### computeListingMetrics branching
 
-### Tooling setup this session
-- `gh` CLI installed and authenticated (HTTPS, GitHub.com)
-- PATH updated: `C:\Program Files\GitHub CLI` added to User PATH
-- All 21 mattpocock/skills installed globally (~/.agents/skills/) and locally
-- `engineering-principles` skill created at ~/.agents/skills/engineering-principles/
-- `UBIQUITOUS_LANGUAGE.md` written to repo root
+- `classification === 'floor'` → `calcFloorFlipMaxBid`, returns `bazaarNet` + `marketNet`, `roi: null`, skips target profit % and mug buffer
+- `classification === 'gap'` → `interpolateGapPrice` overrides `refPrice`, then existing `calcMaxOffer` formula
+- `hq` / `sparse` / null → existing formula unchanged
+
+### UI changes
+
+- `injectAdvisoryStrip`: label changes to "Max Bid (Floor)" / "Max Bid (Est.)" / "Max Offer" per classification. ROI% hidden for floor pieces.
+- `buildContextPanel`: floor shows "Floor Price" + "Bazaar Net" + "Market Net" rows; King's cap hidden. Gap shows "Est. Price" badge instead of comp source badge.
+- Settings modal: new "Min floor profit ($M)" field added between mug buffer and sell-via-trade. Stored in `KEYS.MIN_FLOOR_PROFIT`, default $5M.
 
 ---
 
-## New Pure Function Modules (to be built in v1.29.0–v1.30.0)
+## Key Function Locations (v1.29.0)
 
-| Function | Signature | Priority |
-|----------|-----------|----------|
-| `detectFloorCluster(comps)` | `→ { floorPrice, bestQualityPct, bestBonusPct, clusterSize, isValid }` | Highest — root of algorithm |
-| `classifyListing(listing, floorCluster)` | `→ 'floor' \| 'gap' \| 'hq' \| 'sparse'` | High |
-| `interpolateGapPrice(listing, floorAnchor, premiumAnchor)` | `→ suggestedResalePrice` | Medium |
-| `calcFloorFlipMaxBid(floorPrice, minFloorProfit, marketFee)` | `→ { maxBid, bazaarNet, marketNet }` | Medium |
+| Symbol | Line (approx) | Notes |
+|--------|---------------|-------|
+| `RE_QUALITY` / `RE_ARMOR` | ~900 | Confirmed live DOM format |
+| `detectFloorCluster` | ~400 | Pure function — root of dynamic algorithm |
+| `classifyListing` | ~432 | Pure function |
+| `calcFloorFlipMaxBid` | ~467 | Pure function |
+| `interpolateGapPrice` | ~484 | Pure function |
+| `buildNormalizedComps` | ~2434 | Helper for all-comps normalization |
+| `computeListingMetrics(l)` | ~1631 | Branches on classification |
+| `injectAdvisoryStrip(listing)` | ~1696 | Label + ROI conditional |
+| `buildContextPanel(listing)` | ~1800 | Floor/gap branched display |
+| `enrichListingsFromMarketData()` | ~2478 | Sets floorCluster + classification on each listing |
+| `logListing(listing)` | ~2090 | Snapshot schema — unchanged |
+| `renderLedger()` | ~2100 | Unchanged |
+| `init()` | ~2620 | Main pipeline |
 
 ---
 
 ## Concrete Next Steps
 
-### v1.29.0 — Dynamic floor flip (next session)
-- New setting: `Min floor profit` in settings modal + `KEYS.MIN_FLOOR_PROFIT`
-- `detectFloorCluster(comps)` pure function
-- `classifyListing(listing, floorCluster)` pure function
-- `calcFloorFlipMaxBid(floorPrice, minFloorProfit, marketFee)` pure function
-- `interpolateGapPrice(listing, floorAnchor, premiumAnchor)` pure function
-- `computeListingMetrics(l)` — branch on classification for floor and gap cases
-- `buildContextPanel(listing)` — floor flip display (bazaar net + market net + max bid)
-- Advisory strip — show floor flip label; hide target margin for floor pieces
-- Mug buffer: default 0% for floor flip path
-
 ### v1.30.0 — HQ + exceptional integration
-- `classifyListing` hq branch → hand off to existing Step H comp panel ref price
-- 2× BB warning badge on strip when maxOffer > 2× bbFloor
-- Sparse market badge + comp display with no auto recommendation
-- Context panel: show both item market and bazaar max offers for HQ pieces
+- `classifyListing` hq branch → hand off to existing Step H comp panel ref price (already works via existing formula, but needs explicit label/badge)
+- 2× BB warning badge on strip when `maxOffer > 2 × bbFloor`
+- Sparse market badge on strip ("Sparse") + comp display with no auto recommendation
+- Context panel for HQ: note it uses median comp pricing (existing)
 
 ### v1.31.0 — Manual ledger entry (Step K)
 - `buildAddEntryForm()` inline form above ledger table
@@ -122,25 +110,15 @@ Written to `UBIQUITOUS_LANGUAGE.md`. Defer standardisation cleanup until after S
 
 ---
 
-## Key Function Locations (v1.28.3)
+## Open Questions
 
-| Symbol | Line (approx) | Notes |
-|--------|---------------|-------|
-| `RE_QUALITY` / `RE_ARMOR` | ~820 | Confirmed live DOM format |
-| `computeListingMetrics(l)` | ~1480 | Central pricing calculator — to be branched |
-| `injectAdvisoryStrip(listing)` | ~1518 | Builds strip; to receive floor/gap/hq label |
-| `buildContextPanel(listing)` | ~1592 | To receive floor flip display |
-| `buildCompsPanel(listing)` | ~1650 | Already has Step H median-window logic |
-| `enrichListingsFromMarketData()` | ~2098 | Calls comp fetches; floor cluster detection goes here |
-| `logListing(listing)` | ~1733 | Snapshot schema — manual entry must match |
-| `renderLedger()` | ~1750 | To receive column toggle + P&L redesign |
-| `init()` | ~2215 | Main pipeline |
-| `safeInit()` | ~2260 | MutationObserver debounce |
+- Cluster tightness (12% used): may need tuning after seeing live data. Easy to adjust — just change the default parameter in `detectFloorCluster`.
+- Gap "near premium" thresholds (20pp quality, 4pp bonus): empirical — watch for mis-classifications on live listings.
+- Mug buffer for floor flips: hardcoded 0% in `calcFloorFlipMaxBid`. Community doesn't price it in at $80–125M. Consider adding a per-path toggle later.
+- `gh` CLI: only available in PowerShell currently; restart terminal to get it in Bash.
 
 ---
 
-## Open Questions
+## PRD Reference
 
-- Mug buffer for floor flips: community doesn't appear to price it in at $80–125M floor prices. Default 0%, add toggle later.
-- Exact cluster tightness parameter (10–15%) — may need tuning after seeing live data through the algorithm.
-- `gh` CLI only available in PowerShell currently; restart terminal to get it in Bash.
+Full PRD at `docs/prd-steps-i-through-l.md` and https://github.com/EstradaRPM/Torn-scripts/issues/158

--- a/torn-rw-auction-advisor-v1.user.js
+++ b/torn-rw-auction-advisor-v1.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn RW Auction Advisor
 // @namespace    estradarpm-rw-auction-advisor
-// @version      1.28.3
+// @version      1.29.0
 // @description  Auction house advisor for Riot and Assault armor — evaluates listings for flip potential
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/amarket.php*
@@ -15,7 +15,7 @@
 (function () {
   'use strict';
 
-  const SCRIPT_VERSION = '1.28.3';
+  const SCRIPT_VERSION = '1.29.0';
   const API_KEY = '###PDA-APIKEY###';
 
   // ── Persistence ────────────────────────────────────────────────────────────
@@ -36,6 +36,7 @@
     QUALITY_MATCH_RANGE: 'rw_qualityMatchRange',
     BONUS_MATCH_RANGE  : 'rw_bonusMatchRange',
     LEDGER             : 'rw_ledger',
+    MIN_FLOOR_PROFIT   : 'rw_minFloorProfit',
   };
 
   // ── Runtime state ───────────────────────────────────────────────────────────
@@ -51,6 +52,7 @@
       sellViaTrade     : Store.get(KEYS.SELL_VIA_TRADE) === 'true',
       qualityMatchRange: parseNum(Store.get(KEYS.QUALITY_MATCH_RANGE), 10),
       bonusMatchRange  : parseNum(Store.get(KEYS.BONUS_MATCH_RANGE),    2),
+      minFloorProfit   : parseNum(Store.get(KEYS.MIN_FLOOR_PROFIT), 5_000_000),
     },
 
     // Current parsed auction house listings (supported RW armor sets)
@@ -382,6 +384,106 @@
       );
     });
   })();
+
+  // ── Dynamic pricing: pure algorithm modules ─────────────────────────────────
+
+  /**
+   * Detects the market floor cluster from a normalized comp array.
+   * Cluster = all listings within clusterThreshold (12%) of the cheapest price.
+   * Returns the cheapest price, the best quality and bonus available at that floor,
+   * and a validity flag (isValid = clusterSize >= 3).
+   *
+   * @param {{ price: number, qualityPct: number|null, bonusPct: number|null }[]} comps
+   * @param {number} [clusterThreshold=0.12]
+   * @returns {{ floorPrice: number|null, bestQualityPct: number|null, bestBonusPct: number|null, clusterSize: number, isValid: boolean }}
+   */
+  function detectFloorCluster(comps, clusterThreshold = 0.12) {
+    if (!comps.length) {
+      return { floorPrice: null, bestQualityPct: null, bestBonusPct: null, clusterSize: 0, isValid: false };
+    }
+    const sorted   = comps.slice().sort((a, b) => a.price - b.price);
+    const cheapest = sorted[0].price;
+    const cutoff   = cheapest * (1 + clusterThreshold);
+    const cluster  = sorted.filter(c => c.price <= cutoff);
+    const qs = cluster.map(c => c.qualityPct).filter(q => q != null);
+    const bs = cluster.map(c => c.bonusPct).filter(b => b != null);
+    return {
+      floorPrice    : cheapest,
+      bestQualityPct: qs.length ? Math.max(...qs) : null,
+      bestBonusPct  : bs.length ? Math.max(...bs) : null,
+      clusterSize   : cluster.length,
+      isValid       : cluster.length >= 3,
+    };
+  }
+
+  /**
+   * Classifies a listing relative to the floor cluster and all comps for the piece.
+   *
+   * 'sparse' — fewer than 3 comps in the floor cluster (market too thin for auto-recommendation)
+   * 'floor'  — listing's quality AND bonus are both at or below the floor cluster's best
+   * 'gap'    — listing beats the floor cluster but no close comps exist above it
+   * 'hq'     — listing beats the floor cluster and premium comps near its quality/bonus exist
+   *
+   * @param {{ qualityPct: number|null, bonusPct: number|null }} listing
+   * @param {{ floorPrice: number, bestQualityPct: number|null, bestBonusPct: number|null, isValid: boolean }} floorCluster
+   * @param {{ price: number, qualityPct: number|null, bonusPct: number|null }[]} allComps
+   * @returns {'floor'|'gap'|'hq'|'sparse'}
+   */
+  function classifyListing(listing, floorCluster, allComps) {
+    if (!floorCluster.isValid) return 'sparse';
+
+    const qualBeatsFloor  = listing.qualityPct  != null && floorCluster.bestQualityPct != null
+      && listing.qualityPct  > floorCluster.bestQualityPct;
+    const bonusBeatsFloor = listing.bonusPct    != null && floorCluster.bestBonusPct   != null
+      && listing.bonusPct    > floorCluster.bestBonusPct;
+
+    if (!qualBeatsFloor && !bonusBeatsFloor) return 'floor';
+
+    // Find comps above the floor cluster
+    const clusterCeil   = floorCluster.floorPrice * 1.12;
+    const premiumComps  = allComps.filter(c => c.price > clusterCeil);
+
+    // A "near" premium comp: quality within 20pp OR bonus within 4pp of listing
+    const hasNearPremium = premiumComps.some(c => {
+      const qNear = listing.qualityPct == null || c.qualityPct == null
+        || Math.abs(c.qualityPct - listing.qualityPct) <= 20;
+      const bNear = listing.bonusPct   == null || c.bonusPct   == null
+        || Math.abs(c.bonusPct   - listing.bonusPct)   <= 4;
+      return qNear && bNear;
+    });
+
+    return hasNearPremium ? 'hq' : 'gap';
+  }
+
+  /**
+   * Calculates max bid and channel-specific nets for a floor flip.
+   * Mug buffer is intentionally 0% for floor pieces — the market does not price it in.
+   *
+   * @param {number} floorPrice
+   * @param {number} minFloorProfit  - absolute minimum profit required (pre-fee, in $)
+   * @param {number} marketFee       - e.g. 0.05
+   * @returns {{ maxBid: number, bazaarNet: number, marketNet: number }}
+   */
+  function calcFloorFlipMaxBid(floorPrice, minFloorProfit, marketFee) {
+    const maxBid    = floorPrice - minFloorProfit;
+    const bazaarNet = minFloorProfit;                                   // no fee in bazaar
+    const marketNet = Math.round(floorPrice * (1 - marketFee)) - maxBid;
+    return { maxBid, bazaarNet, marketNet };
+  }
+
+  /**
+   * Interpolates a suggested resale price for a gap piece.
+   * Leans 25–30% toward the floor anchor (default 27%) so the piece reads as a deal
+   * relative to the premium market while still commanding a meaningful premium over floor.
+   *
+   * @param {number} floorAnchor    - floor cluster price (cheapest comp)
+   * @param {number} premiumAnchor  - cheapest comp above the floor cluster
+   * @param {number} [lean=0.27]    - fraction of the floor→premium range to add to floor
+   * @returns {number}
+   */
+  function interpolateGapPrice(floorAnchor, premiumAnchor, lean = 0.27) {
+    return Math.round(floorAnchor + lean * (premiumAnchor - floorAnchor));
+  }
 
   // ── API key helper ──────────────────────────────────────────────────────────
 
@@ -1483,6 +1585,10 @@
         <input id="rwa-input-mug" class="rwa-input" type="number" min="0" max="30" step="1">
       </div>
       <div class="rwa-field">
+        <label for="rwa-input-min-floor-profit">Min floor profit <span style="font-weight:400;color:#4a6070">($M — floor flips only)</span></label>
+        <input id="rwa-input-min-floor-profit" class="rwa-input" type="number" min="0" step="0.5">
+      </div>
+      <div class="rwa-field">
         <label>Sell via trade <span style="font-weight:400;color:#4a6070">(skips 5% market fee)</span></label>
         <div class="rwa-toggle-row">
           <button id="rwa-toggle-trade" class="rwa-toggle" aria-label="Sell via trade"></button>
@@ -1509,28 +1615,55 @@
 
   // ── Element refs ─────────────────────────────────────────────────────────────
 
-  const profitInput     = settingsModal.querySelector('#rwa-input-profit');
-  const mugInput        = settingsModal.querySelector('#rwa-input-mug');
-  const tradeToggle     = settingsModal.querySelector('#rwa-toggle-trade');
-  const tradeLabel      = settingsModal.querySelector('#rwa-toggle-trade-label');
-  const apikeyInput     = settingsModal.querySelector('#rwa-input-apikey');
-  const qualRangeInput  = settingsModal.querySelector('#rwa-input-quality-range');
-  const bonusRangeInput = settingsModal.querySelector('#rwa-input-bonus-range');
-  const apikeyHint      = settingsModal.querySelector('#rwa-apikey-hint');
-  const sourcesBody     = settingsModal.querySelector('#rwa-sources-body');
+  const profitInput         = settingsModal.querySelector('#rwa-input-profit');
+  const mugInput            = settingsModal.querySelector('#rwa-input-mug');
+  const minFloorProfitInput = settingsModal.querySelector('#rwa-input-min-floor-profit');
+  const tradeToggle         = settingsModal.querySelector('#rwa-toggle-trade');
+  const tradeLabel          = settingsModal.querySelector('#rwa-toggle-trade-label');
+  const apikeyInput         = settingsModal.querySelector('#rwa-input-apikey');
+  const qualRangeInput      = settingsModal.querySelector('#rwa-input-quality-range');
+  const bonusRangeInput     = settingsModal.querySelector('#rwa-input-bonus-range');
+  const apikeyHint          = settingsModal.querySelector('#rwa-apikey-hint');
+  const sourcesBody         = settingsModal.querySelector('#rwa-sources-body');
 
   // ── Inline render ────────────────────────────────────────────────────────────
 
   function computeListingMetrics(l) {
-    const { baseBonusPct, highTierThreshold } = ARMOR_SCORING[l.armorSet] ?? ARMOR_SCORING.Riot;
     const bbRate = MEM.bbRate?.rate ?? null;
 
     const bbFloor = (BB_FLOOR_SETS.has(l.armorSet) && bbRate && l.rarity)
       ? calculateBBFloor(l.armorSet, l.rarity, bbRate)
       : null;
 
-    const refPrice     = l.refPrice ?? null;
-    const kingCap      = l.kingCap  ?? null;
+    const classification = l.classification ?? null;
+    const bid            = l.currentBid;
+
+    // ── Floor flip: bypass target margin and mug buffer entirely ──────────────
+    if (classification === 'floor' && l.floorCluster?.floorPrice != null) {
+      const { maxBid, bazaarNet, marketNet } = calcFloorFlipMaxBid(
+        l.floorCluster.floorPrice,
+        MEM.settings.minFloorProfit,
+        0.05
+      );
+      const signalColor = bid != null
+        ? (bid < maxBid ? '#00cc66' : '#ff4444')
+        : '#8aa898';
+      return {
+        bbFloor, refPrice: l.floorCluster.floorPrice,
+        maxOffer: maxBid, bazaarNet, marketNet,
+        netProfit: marketNet, roi: null, signalColor, classification,
+      };
+    }
+
+    // ── Gap: interpolate resale price between floor anchor and cheapest premium comp ──
+    let refPrice = l.refPrice ?? null;
+    if (classification === 'gap' && l.floorCluster?.floorPrice != null) {
+      const premiumAnchor = l.gapPremiumAnchor ?? (l.floorCluster.floorPrice * 2.0);
+      refPrice = interpolateGapPrice(l.floorCluster.floorPrice, premiumAnchor);
+    }
+
+    // ── HQ / sparse / unclassified: existing formula ──────────────────────────
+    const kingCap      = l.kingCap ?? null;
     const formulaOffer = refPrice != null
       ? calcMaxOffer({
           refPrice,
@@ -1544,7 +1677,6 @@
       ? Math.min(formulaOffer, kingCap)
       : formulaOffer;
 
-    const bid = l.currentBid;
     let netProfit = null, roi = null;
     if (bid != null && refPrice != null) {
       const marketFee   = MEM.settings.sellViaTrade ? 0 : 0.05;
@@ -1558,30 +1690,33 @@
       ? (bid < maxOffer ? '#00cc66' : '#ff4444')
       : '#8aa898';
 
-    return { bbFloor, refPrice, maxOffer, netProfit, roi, signalColor };
+    return { bbFloor, refPrice, maxOffer, bazaarNet: null, marketNet: null, netProfit, roi, signalColor, classification };
   }
 
   function injectAdvisoryStrip(listing) {
     if (!listing.el) return;
     listing.el.querySelector('.rwa-strip')?.remove();
 
-    const { maxOffer, roi, signalColor } = computeListingMetrics(listing);
+    const { maxOffer, roi, signalColor, classification } = computeListingMetrics(listing);
     const isLoading = maxOffer == null && !MEM.fetchError;
 
     const strip = document.createElement('div');
     strip.className = 'rwa-strip';
 
+    const offerLabel = classification === 'floor' ? 'Max Bid (Floor)'
+                     : classification === 'gap'   ? 'Max Bid (Est.)'
+                     : 'Max Offer';
     const offerHtml = isLoading
       ? `<span class="rwa-strip-loading">fetching…</span>`
       : `<span class="rwa-strip-val" style="color:${escHtml(signalColor)}">${escHtml(fmtM(maxOffer))}</span>`;
-    const roiHtml = (!isLoading && roi != null)
+    const roiHtml = (!isLoading && roi != null && classification !== 'floor')
       ? `<span class="rwa-strip-roi" style="color:${escHtml(signalColor)}">${roi.toFixed(1)}%</span>`
       : '';
 
     strip.innerHTML = `
       <div class="rwa-strip-main">
         <div class="rwa-strip-offer">
-          <span class="rwa-strip-label">Max Offer</span>
+          <span class="rwa-strip-label">${escHtml(offerLabel)}</span>
           ${offerHtml}
           ${roiHtml}
         </div>
@@ -1666,53 +1801,88 @@
   }
 
   function buildContextPanel(listing) {
-    const { bbFloor, refPrice, netProfit } = computeListingMetrics(listing);
+    const { bbFloor, refPrice, netProfit, bazaarNet, marketNet, classification } = computeListingMetrics(listing);
     const { rarity, qualityPct, bonusPct, bonusType, tier, compSource, kingCap, qualityEstimated } = listing;
 
-    const rarityClass = rarity ? `rwa-rarity-${rarity}` : '';
-    const srcLabel = { interpolated: 'interp', 'quality-match': 'match', 'single-bound': '~', 'bonus-only': '~' }[compSource] ?? '~';
-    const tierBadge = tier === 'exceptional'
-      ? `<span class="rwa-badge rwa-badge-excep">EXCEP</span>`
-      : tier === 'hq'
-        ? `<span class="rwa-badge rwa-badge-hq">HQ</span>`
-        : '';
-    const profitColor = netProfit == null ? '#8aa898' : netProfit >= 0 ? '#00cc66' : '#ff4444';
+    const rarityClass  = rarity ? `rwa-rarity-${rarity}` : '';
+    const profitColor  = netProfit  == null ? '#8aa898' : netProfit  >= 0 ? '#00cc66' : '#ff4444';
+    const bazaarColor  = bazaarNet  == null ? '#8aa898' : bazaarNet  >= 0 ? '#00cc66' : '#ff4444';
+    const marketColor  = marketNet  == null ? '#8aa898' : marketNet  >= 0 ? '#00cc66' : '#ff4444';
 
     const rows = [];
 
+    // BB Floor — always shown
     rows.push(`<div class="rwa-context-row">
       <span class="rwa-context-lbl">BB Floor</span>
       <span class="rwa-context-val ${rarityClass}">${escHtml(fmtM(bbFloor))}</span>
     </div>`);
 
-    rows.push(`<div class="rwa-context-row">
-      <span class="rwa-context-lbl">Comp Price</span>
-      <span class="rwa-context-val">${escHtml(fmtM(refPrice))}</span>
-      <span class="rwa-badge rwa-badge-src">${escHtml(srcLabel)}</span>
-    </div>`);
-
-    if (qualityPct != null || bonusPct != null) {
-      const qStr = qualityPct != null ? `Q${qualityEstimated ? '~' : ''}${qualityPct.toFixed(0)}%` : '';
-      const bStr = bonusPct  != null ? `${bonusPct.toFixed(0)}% ${escHtml(bonusType ?? '')}` : '';
+    if (classification === 'floor') {
+      // Floor flip display: floor price + quality + channel-specific nets
       rows.push(`<div class="rwa-context-row">
-        <span class="rwa-context-lbl">Quality</span>
-        <span class="rwa-context-val">${escHtml([qStr, bStr].filter(Boolean).join(' · '))}</span>
-        ${tierBadge}
+        <span class="rwa-context-lbl">Floor Price</span>
+        <span class="rwa-context-val">${escHtml(fmtM(refPrice))}</span>
+        <span class="rwa-badge rwa-badge-src">floor</span>
+      </div>`);
+
+      if (qualityPct != null || bonusPct != null) {
+        const qStr = qualityPct != null ? `Q${qualityEstimated ? '~' : ''}${qualityPct.toFixed(0)}%` : '';
+        const bStr = bonusPct  != null ? `${bonusPct.toFixed(0)}% ${escHtml(bonusType ?? '')}` : '';
+        rows.push(`<div class="rwa-context-row">
+          <span class="rwa-context-lbl">Quality</span>
+          <span class="rwa-context-val">${escHtml([qStr, bStr].filter(Boolean).join(' · '))}</span>
+        </div>`);
+      }
+
+      rows.push(`<div class="rwa-context-row">
+        <span class="rwa-context-lbl">Bazaar Net</span>
+        <span class="rwa-context-val" style="color:${escHtml(bazaarColor)}">${escHtml(fmtM(bazaarNet))}</span>
+      </div>`);
+      rows.push(`<div class="rwa-context-row">
+        <span class="rwa-context-lbl">Market Net</span>
+        <span class="rwa-context-val" style="color:${escHtml(marketColor)}">${escHtml(fmtM(marketNet))}</span>
+      </div>`);
+    } else {
+      // Standard display (hq / gap / sparse)
+      const srcLabel = { interpolated: 'interp', 'quality-match': 'match', 'single-bound': '~', 'bonus-only': '~' }[compSource] ?? '~';
+      const tierBadge = tier === 'exceptional'
+        ? `<span class="rwa-badge rwa-badge-excep">EXCEP</span>`
+        : tier === 'hq'
+          ? `<span class="rwa-badge rwa-badge-hq">HQ</span>`
+          : '';
+      const isGap = classification === 'gap';
+
+      rows.push(`<div class="rwa-context-row">
+        <span class="rwa-context-lbl">${isGap ? 'Est. Price' : 'Comp Price'}</span>
+        <span class="rwa-context-val">${escHtml(fmtM(refPrice))}</span>
+        ${isGap
+          ? `<span class="rwa-badge rwa-badge-src">est.</span>`
+          : `<span class="rwa-badge rwa-badge-src">${escHtml(srcLabel)}</span>`}
+      </div>`);
+
+      if (qualityPct != null || bonusPct != null) {
+        const qStr = qualityPct != null ? `Q${qualityEstimated ? '~' : ''}${qualityPct.toFixed(0)}%` : '';
+        const bStr = bonusPct  != null ? `${bonusPct.toFixed(0)}% ${escHtml(bonusType ?? '')}` : '';
+        rows.push(`<div class="rwa-context-row">
+          <span class="rwa-context-lbl">Quality</span>
+          <span class="rwa-context-val">${escHtml([qStr, bStr].filter(Boolean).join(' · '))}</span>
+          ${tierBadge}
+        </div>`);
+      }
+
+      if (kingCap != null) {
+        rows.push(`<div class="rwa-context-row">
+          <span class="rwa-context-lbl">King's Cap</span>
+          <span class="rwa-context-val">${escHtml(fmtM(kingCap))}</span>
+          <span class="rwa-badge rwa-badge-cap">!</span>
+        </div>`);
+      }
+
+      rows.push(`<div class="rwa-context-row">
+        <span class="rwa-context-lbl">Net Profit</span>
+        <span class="rwa-context-val" style="color:${escHtml(profitColor)}">${escHtml(fmtM(netProfit))}</span>
       </div>`);
     }
-
-    if (kingCap != null) {
-      rows.push(`<div class="rwa-context-row">
-        <span class="rwa-context-lbl">King's Cap</span>
-        <span class="rwa-context-val">${escHtml(fmtM(kingCap))}</span>
-        <span class="rwa-badge rwa-badge-cap">!</span>
-      </div>`);
-    }
-
-    rows.push(`<div class="rwa-context-row">
-      <span class="rwa-context-lbl">Net Profit</span>
-      <span class="rwa-context-val" style="color:${escHtml(profitColor)}">${escHtml(fmtM(netProfit))}</span>
-    </div>`);
 
     const panel = document.createElement('div');
     panel.className = 'rwa-context';
@@ -2102,10 +2272,11 @@
 
   if (Store.get('rw_apikey')) apikeyInput.placeholder = '(key saved)';
 
-  profitInput.value     = MEM.settings.targetProfitPct;
-  mugInput.value        = MEM.settings.mugBufferPct;
-  qualRangeInput.value  = MEM.settings.qualityMatchRange;
-  bonusRangeInput.value = MEM.settings.bonusMatchRange;
+  profitInput.value         = MEM.settings.targetProfitPct;
+  mugInput.value            = MEM.settings.mugBufferPct;
+  minFloorProfitInput.value = MEM.settings.minFloorProfit / 1_000_000;
+  qualRangeInput.value      = MEM.settings.qualityMatchRange;
+  bonusRangeInput.value     = MEM.settings.bonusMatchRange;
   if (MEM.settings.sellViaTrade) {
     tradeToggle.classList.add('rwa-on');
     tradeLabel.textContent = 'On';
@@ -2124,6 +2295,14 @@
     if (isNaN(v) || v < 0 || v > 30) return;
     MEM.settings.mugBufferPct = v;
     Store.set(KEYS.MUG_BUFFER_PCT, String(v));
+    renderInline();
+  });
+
+  minFloorProfitInput.addEventListener('change', () => {
+    const v = parseFloat(minFloorProfitInput.value);
+    if (isNaN(v) || v < 0) return;
+    MEM.settings.minFloorProfit = Math.round(v * 1_000_000);
+    Store.set(KEYS.MIN_FLOOR_PROFIT, String(MEM.settings.minFloorProfit));
     renderInline();
   });
 
@@ -2244,6 +2423,47 @@
     return Math.max(0, Math.min(100, slope * armorStat + intercept));
   }
 
+  /**
+   * Builds a flat array of all raw comp listings for a specific armor piece
+   * (by itemId) from both the item market and TornW3B bazaar caches.
+   * Normalised to { price, qualityPct, bonusPct } for use by detectFloorCluster.
+   *
+   * @param {object} listing - a MEM.listings entry
+   * @returns {{ price: number, qualityPct: number|null, bonusPct: number|null }[]}
+   */
+  function buildNormalizedComps(listing) {
+    const itemId = armorItemIds[listing.name];
+    const w3bKey = `${listing.armorSet}_${listing.rarity}`;
+    const result = [];
+
+    const imRaw = itemId != null ? MEM.itemMarketComps[itemId] : null;
+    if (imRaw?.listings) {
+      for (const l of imRaw.listings) {
+        result.push({
+          price     : l.price,
+          qualityPct: l.item_details?.stats?.quality              ?? null,
+          bonusPct  : l.item_details?.bonuses?.[0]?.value         ?? null,
+        });
+      }
+    }
+
+    const w3bAll = MEM.tornw3bComps[w3bKey];
+    if (w3bAll && itemId != null) {
+      for (const w of w3bAll) {
+        if (w.itemId !== itemId) continue;
+        const q    = parseFloat(w.quality);
+        const bVal = Object.values(w.bonuses ?? {})[0]?.value ?? null;
+        result.push({
+          price     : w.price,
+          qualityPct: isNaN(q) ? null : q,
+          bonusPct  : bVal,
+        });
+      }
+    }
+
+    return result;
+  }
+
   // Enriches each listing with refPrice and kingCap per King's RW Guide.
   //
   // refPrice — quality-aware resale estimate, same logic for all tiers:
@@ -2277,6 +2497,11 @@
       const tier = classifyArmorTier(listing.qualityPct, listing.bonusPct, baseBonusPct, highTierThreshold);
       listing.tier = tier;
 
+      // ── Floor cluster detection (runs before the early-exit so every listing gets classified) ──
+      const allComps     = buildNormalizedComps(listing);
+      const floorCluster = detectFloorCluster(allComps);
+      listing.floorCluster = floorCluster;
+
       // ── Quality-aware refPrice (identical logic for all tiers) ──────────────
       const imComp  = getItemMarketComp(itemId, listing.bonusPct, listing.qualityPct);
       const w3bComp = getTornW3BComp(listing.name, listing.armorSet, listing.rarity, listing.bonusPct, listing.qualityPct);
@@ -2284,7 +2509,11 @@
       const imPrice  = imComp?.price  ?? Infinity;
       const w3bPrice = w3bComp?.price ?? Infinity;
 
-      if (imPrice === Infinity && w3bPrice === Infinity) continue;
+      if (imPrice === Infinity && w3bPrice === Infinity) {
+        listing.classification   = classifyListing(listing, floorCluster, allComps);
+        listing.gapPremiumAnchor = null;
+        continue;
+      }
 
       const imQM  = imComp?.qualityMatched  ?? false;
       const w3bQM = w3bComp?.qualityMatched ?? false;
@@ -2374,6 +2603,16 @@
       listing.interpUpper   = interpUpper;
       listing.imPrice       = imPrice  === Infinity ? null : imPrice;
       listing.w3bPrice      = w3bPrice === Infinity ? null : w3bPrice;
+
+      // ── Classify listing relative to floor cluster ──────────────────────────
+      listing.classification = classifyListing(listing, floorCluster, allComps);
+      if (listing.classification === 'gap') {
+        const clusterCeil   = floorCluster.floorPrice * 1.12;
+        const premiumPrices = allComps.filter(c => c.price > clusterCeil).map(c => c.price);
+        listing.gapPremiumAnchor = premiumPrices.length ? Math.min(...premiumPrices) : null;
+      } else {
+        listing.gapPremiumAnchor = null;
+      }
     }
   }
 


### PR DESCRIPTION
﻿## Summary

- Replaces the static single-formula pricing model with a dynamic classification-based algorithm derived entirely from live comp data
- Adds four pure functions: detectFloorCluster, classifyListing, calcFloorFlipMaxBid, interpolateGapPrice
- Adds Min floor profit setting (default $5M, applies only to floor flip path)
- computeListingMetrics branches on classification: floor uses calcFloorFlipMaxBid (skips target margin + mug buffer), gap uses interpolateGapPrice, hq/sparse use existing formula unchanged
- Advisory strip label changes per classification
- Context panel for floor pieces shows Floor Price + Bazaar Net + Market Net

## Classification logic

- floor: listing quality AND bonus both at or below floor cluster best — quick flip, min-profit anchored max bid
- gap: beats floor cluster but no near premium comps — interpolated resale at 27% of floor-to-premium range
- hq: beats floor cluster with near premium comps present — existing comp panel median pricing (unchanged)
- sparse: fewer than 3 comps in cluster — existing formula, no label until v1.30.0

## Test plan

- [ ] Load amarket.php with yellow Riot/Assault listings; verify floor pieces show "Max Bid (Floor)" label and bazaar/market net rows in Details panel
- [ ] Verify min floor profit default is $5M; change in Settings and confirm strip re-renders
- [ ] Verify gap pieces show "Max Bid (Est.)" label and "Est. Price" badge in Details
- [ ] Verify HQ pieces still show "Max Offer" and existing comp panel median pricing
- [ ] Verify ROI% is hidden on floor pieces, shown on gap/hq
- [ ] Open Settings; confirm "Min floor profit" field appears between mug buffer and sell-via-trade; verify it persists after page reload
- [ ] Log a floor flip listing and confirm ledger entry captures maxOffer (= maxBid) correctly

## Related

Closes part of issue #158 (Steps I-L PRD). This PR covers Step I (v1.29.0). Steps J-L follow.

Generated with [Claude Code](https://claude.com/claude-code)
