### PR TITLE
docs: add Engineering Principles to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,27 @@ Keep the file under 300 lines. Replace stale entries rather than appending indef
 
 ---
 
+## Shell & CLI Constraints (Windows)
+
+PowerShell 5.1 (the shell available here) cannot pass long strings to native executables via here-strings — arguments over ~893 bytes are silently truncated or cause a parse error.
+
+**Rule: never use `--body` or `--title` with long inline strings when calling `gh`.** Instead, write the body to a temp file and use `--body-file`:
+
+```powershell
+$body = @'
+## Summary
+...
+'@
+$tmp = [System.IO.Path]::GetTempFileName()
+[System.IO.File]::WriteAllText($tmp, $body, [System.Text.Encoding]::UTF8)
+& "C:\Program Files\GitHub CLI\gh.exe" pr create --title "..." --body-file $tmp
+Remove-Item $tmp
+```
+
+**`gh` is only available via full path** (`C:\Program Files\GitHub CLI\gh.exe`) in PowerShell. It is not on the PATH in Bash. Always use the full path in PowerShell tool calls.
+
+---
+
 ## Repository Purpose
 
 Personal collection of scripts for the browser game **Torn City** (torn.com). Scripts range from Tampermonkey/Greasemonkey userscripts (`.user.js`) to standalone tools and utilities. All scripts are Torn-specific.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,38 @@ PDA detects updates by fetching `@updateURL` and comparing the remote `@version`
 
 ---
 
+## Engineering Principles
+
+Apply these to every task, plan, review, or design decision. They are constraints, not guidelines — check work against all of them before proceeding.
+
+### 1. Avoid complexity
+
+Complexity takes two forms:
+- **Obscurity** — important information is not obvious; a reader has to dig to understand what something does or why.
+- **Change amplification** — a simple change requires modifications in many places.
+
+Before adding anything — a parameter, an abstraction, a file, a concept — ask: does this make the system easier or harder to understand and modify? If harder, don't add it. The symptom of complexity is always the same: you have to hold too many things in your head at once.
+
+### 2. Always take small, deliberate steps
+
+Never make several changes at once. Each step should do exactly one thing, leave the system in a working state, and be verifiable on its own before the next step begins. If you need a list to describe the step, it's too big.
+
+### 3. The rate of feedback is your speed limit
+
+Before starting any step, know: how will I know this worked? If the answer is "I'll check it later" or "it's hard to test," stop and find a faster feedback path first. Slow feedback forces guessing. Guessing creates bugs. Bugs create complexity.
+
+### 4. Never take on a task that's too big
+
+A task is too big when you can't hold the full change in your head, can't describe a clean intermediate state, or the feedback loop spans the entire change. Decompose first. Find the smallest change that is independently useful and verifiable. Do that. Then reassess. If you can't decompose it, you don't understand it well enough yet — understanding it is the first step.
+
+### 5. The best modules are deep
+
+A deep module has a simple interface and a lot of functionality behind it. A shallow module has an interface nearly as complex as its implementation — it leaks internals and adds complexity instead of hiding it. Push complexity inward, not outward. Make the interface the smallest surface that still gives callers what they need.
+
+**Deletion test:** if you deleted this module, would its complexity disappear (shallow, not earning its keep) or reappear in N different callers (deep, earning its keep)? Only keep modules that pass.
+
+---
+
 ## Architecture Patterns
 
 The gym optimizer establishes patterns worth reusing in future scripts:


### PR DESCRIPTION
## Summary

- Adds a new **Engineering Principles** section to `CLAUDE.md`, placed between JavaScript Style and Architecture Patterns
- Embeds all five principles from the `/engineering-principles` skill (condensed for in-context use)
- Principles now load automatically at session start without needing to invoke the skill

## What changed

The five principles added:
1. **Avoid complexity** — obscurity and change amplification as the two failure modes
2. **Small, deliberate steps** — one thing per step, system stays working, verifiable before moving on
3. **Feedback rate is the speed limit** — know how you will verify before you start
4. **Never take on too-big tasks** — decompose first; if you cannot decompose, you do not understand it yet
5. **Deep modules** — simple interface, complex internals; deletion test to judge whether a module earns its keep

## Reviewer notes

No script changes — CLAUDE.md only. The principles are phrased as constraints, not suggestions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)