### PR TITLE
feat(advisor): HQ + sparse classification UI badges (v1.30.0)

### DIFF
--- a/torn-rw-auction-advisor-v1.user.js
+++ b/torn-rw-auction-advisor-v1.user.js
@@ -1698,7 +1698,7 @@
     if (!listing.el) return;
     listing.el.querySelector('.rwa-strip')?.remove();
 
-    const { maxOffer, roi, signalColor, classification } = computeListingMetrics(listing);
+    const { maxOffer, roi, signalColor, classification, bbFloor } = computeListingMetrics(listing);
     const isLoading = maxOffer == null && !MEM.fetchError;
 
     const strip = document.createElement('div');
@@ -1716,6 +1716,9 @@
     const sparseBadgeHtml = classification === 'sparse'
       ? `<span class="rwa-badge rwa-badge-sparse">Sparse</span>`
       : '';
+    const twoBBHtml = (!isLoading && bbFloor != null && maxOffer != null && maxOffer > 2 * bbFloor)
+      ? `<span class="rwa-badge rwa-badge-cap">2×BB</span>`
+      : '';
 
     strip.innerHTML = `
       <div class="rwa-strip-main">
@@ -1724,6 +1727,7 @@
           ${offerHtml}
           ${roiHtml}
           ${sparseBadgeHtml}
+          ${twoBBHtml}
         </div>
         <div class="rwa-strip-actions">
           <button class="rwa-btn rwa-btn-details">&#9660; Details</button>

--- a/torn-rw-auction-advisor-v1.user.js
+++ b/torn-rw-auction-advisor-v1.user.js
@@ -1853,7 +1853,9 @@
       </div>`);
     } else {
       // Standard display (hq / gap / sparse)
-      const srcLabel = { interpolated: 'interp', 'quality-match': 'match', 'single-bound': '~', 'bonus-only': '~' }[compSource] ?? '~';
+      const srcLabel = classification === 'hq'
+        ? 'comp'
+        : ({ interpolated: 'interp', 'quality-match': 'match', 'single-bound': '~', 'bonus-only': '~' }[compSource] ?? '~');
       const tierBadge = tier === 'exceptional'
         ? `<span class="rwa-badge rwa-badge-excep">EXCEP</span>`
         : tier === 'hq'

--- a/torn-rw-auction-advisor-v1.user.js
+++ b/torn-rw-auction-advisor-v1.user.js
@@ -1820,6 +1820,14 @@
 
     const rows = [];
 
+    // Sparse note — prepended so it's the first thing visible when Details opens
+    if (classification === 'sparse') {
+      rows.push(`<div class="rwa-context-row">
+        <span class="rwa-context-lbl">Data</span>
+        <span class="rwa-badge rwa-badge-sparse">Sparse</span>
+      </div>`);
+    }
+
     // BB Floor — always shown
     rows.push(`<div class="rwa-context-row">
       <span class="rwa-context-lbl">BB Floor</span>

--- a/torn-rw-auction-advisor-v1.user.js
+++ b/torn-rw-auction-advisor-v1.user.js
@@ -1426,10 +1426,11 @@
       padding: 1px 5px;
       text-transform: uppercase;
     }
-    .rwa-badge-src   { background: #0c2030; border: 1px solid #1a3a50; color: #5a9ab0; }
-    .rwa-badge-excep { background: #1a0c30; border: 1px solid #3a1a50; color: #b05af0; }
-    .rwa-badge-hq    { background: #0c1a10; border: 1px solid #1a3a20; color: #4ab060; }
-    .rwa-badge-cap   { background: #2a1800; border: 1px solid #4a3000; color: #f0a030; }
+    .rwa-badge-src    { background: #0c2030; border: 1px solid #1a3a50; color: #5a9ab0; }
+    .rwa-badge-excep  { background: #1a0c30; border: 1px solid #3a1a50; color: #b05af0; }
+    .rwa-badge-hq     { background: #0c1a10; border: 1px solid #1a3a20; color: #4ab060; }
+    .rwa-badge-cap    { background: #2a1800; border: 1px solid #4a3000; color: #f0a030; }
+    .rwa-badge-sparse { background: #1a1800; border: 1px solid #3a3000; color: #c8a820; }
     .rwa-rarity-yellow { color: #e8d070; }
     .rwa-rarity-orange { color: #f0a030; }
     .rwa-rarity-red    { color: #f04040; }
@@ -1712,6 +1713,9 @@
     const roiHtml = (!isLoading && roi != null && classification !== 'floor')
       ? `<span class="rwa-strip-roi" style="color:${escHtml(signalColor)}">${roi.toFixed(1)}%</span>`
       : '';
+    const sparseBadgeHtml = classification === 'sparse'
+      ? `<span class="rwa-badge rwa-badge-sparse">Sparse</span>`
+      : '';
 
     strip.innerHTML = `
       <div class="rwa-strip-main">
@@ -1719,6 +1723,7 @@
           <span class="rwa-strip-label">${escHtml(offerLabel)}</span>
           ${offerHtml}
           ${roiHtml}
+          ${sparseBadgeHtml}
         </div>
         <div class="rwa-strip-actions">
           <button class="rwa-btn rwa-btn-details">&#9660; Details</button>

--- a/torn-rw-auction-advisor-v1.user.js
+++ b/torn-rw-auction-advisor-v1.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn RW Auction Advisor
 // @namespace    estradarpm-rw-auction-advisor
-// @version      1.29.0
+// @version      1.30.0
 // @description  Auction house advisor for Riot and Assault armor — evaluates listings for flip potential
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/amarket.php*
@@ -15,7 +15,7 @@
 (function () {
   'use strict';
 
-  const SCRIPT_VERSION = '1.29.0';
+  const SCRIPT_VERSION = '1.30.0';
   const API_KEY = '###PDA-APIKEY###';
 
   // ── Persistence ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Amber **Sparse** badge on the advisory strip for listings where market data is too thin to trust (still shows the computed offer as a reference)
- Orange **2×BB** badge on the strip when the computed max offer exceeds twice the BB floor — flags high-value exceptional pieces
- Context panel source badge reads **comp** (not `~`) for `hq` listings, making it clear the price came from median comparable pricing
- Context panel shows a **Data: Sparse** note row at the top for sparse listings so the caveat is visible when Details is expanded

No algorithm changes. All classification data already existed on the listing object from v1.29.0 — this is purely a display layer on top of it.

Closes #162

## Test plan

- [ ] Sparse listing: amber "Sparse" badge appears on strip; offer value and ROI% still display
- [ ] Non-sparse listing: no Sparse badge
- [ ] Sparse listing expanded: "Data: Sparse" row is first row in Details panel
- [ ] HQ listing expanded: source badge on Comp Price row reads "comp" not "~"
- [ ] 2×BB badge: verify via browser console — set `MEM.bbRate.rate` to a low value temporarily so a known listing crosses the threshold; orange "2×BB" badge appears
- [ ] Floor and gap listings: unaffected — no new badges, labels unchanged
- [ ] `@version` and `SCRIPT_VERSION` both read `1.30.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
