### PR TITLE
fix(snipe): sync MO alert path — ROI threshold, cooldown, audio v1.54.0 (#193)

### DIFF
--- a/torn-snipe-tracker-v1.user.js
+++ b/torn-snipe-tracker-v1.user.js
@@ -1,7 +1,7 @@
 ﻿// ==UserScript==
 // @name         Torn Snipe Tracker
 // @namespace    estradarpm-snipe-tracker
-// @version      1.53.0
+// @version      1.54.0
 // @description  Bazaar snipe detector and trade ledger for Torn City
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/*
@@ -31,7 +31,7 @@
     window.__stPollTimer = null;
   }
 
-  const SCRIPT_VERSION   = '1.53.0';
+  const SCRIPT_VERSION   = '1.54.0';
   const API_KEY          = '###PDA-APIKEY###';
   const BLOCK_VALUE_PCT  = 0.10;
   const FREQ_WINDOW      = 2 * 24 * 60 * 60 * 1000;
@@ -2631,15 +2631,26 @@
     const entry = MEM.data.watchlist.find(w => w.itemId === itemId && w.enabled !== false);
     if (!entry) return;
     const res = MEM.poll.pollResults[itemId];
-    if (!res || res.error || !res.fairValue) return;
-    const threshold = entry.threshold ?? MEM.data.settings.threshold ?? 10;
-    const snipeCutoff = res.fairValue * (1 - threshold / 100);
+    if (!res || res.error) return;
+    const threshold  = entry.threshold ?? MEM.data.settings.threshold ?? 10;
+    const sellTarget = entry.manualSellTarget ?? res.recommendedSellTarget ?? null;
     for (const node of addedNodes) {
       if (node.nodeType !== Node.ELEMENT_NODE) continue;
-      const hits = parseNodePrices(node).filter(p => p <= snipeCutoff);
-      if (hits.length > 0) {
+      const prices = parseNodePrices(node);
+      const hit = prices.find(p => {
+        if (sellTarget != null) return (sellTarget - p) / p >= threshold / 100;
+        return res.fairValue != null && p < res.fairValue * (1 - threshold / 100);
+      });
+      if (hit != null) {
         flashCardGreen(itemId);
-        injectSnipeCard(itemId, Math.min(...hits), node);
+        injectSnipeCard(itemId, hit, node);
+        if (MEM.data.settings.snipeAlerts ?? true) {
+          const lastFired = MEM.poll.lastAlertedAt[itemId] ?? 0;
+          if (Date.now() - lastFired > ALERT_COOLDOWN_MS) {
+            fireSnipeAlert(entry);
+            MEM.poll.lastAlertedAt[itemId] = Date.now();
+          }
+        }
         return;
       }
     }


### PR DESCRIPTION
﻿## Summary

- `checkNodesForSnipes` now uses the same ROI-based threshold logic as `checkSnipeAlerts`: `(sellTarget - p) / p >= threshold/100`, with fallback to `p < fairValue * (1 - threshold/100)` when no sell target
- Added `lastAlertedAt` cooldown guard (same `ALERT_COOLDOWN_MS` as the poll path) so rapid DOM mutations don't spam alerts
- Added `fireSnipeAlert` call on the MO hot path, guarded by the `snipeAlerts` setting — MO detections now play the chime and fire the browser/PDA notification

Closes #193

## Test plan

- [ ] Open item market for a watched item; trigger a DOM mutation that adds a below-threshold listing; confirm alert fires immediately without waiting for poll
- [ ] Trigger two rapid mutations for the same item within cooldown window; confirm only one audio alert fires
- [ ] Set `snipeAlerts` to off in settings; verify MO detection still flashes card but no audio/notification
- [ ] Confirm poll-path behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)