### PR TITLE
feat(rwth): v0.3.94 - projected/realized ROI + below-cost marker (#338)

### DIFF
--- a/TORN-RW-trading-hub.user.js
+++ b/TORN-RW-trading-hub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Torn RW Trading Hub
 // @namespace    estradarpm-rw-trading-hub
-// @version      0.3.93
+// @version      0.3.94
 // @description  Trader's workbench for ranked-war armor & weapon flipping — ledger + advertising hub
 // @author       Built for EstradaRPM
 // @match        https://www.torn.com/*
@@ -15,7 +15,7 @@
 (function () {
   'use strict';
 
-  const SCRIPT_VERSION = '0.3.93';
+  const SCRIPT_VERSION = '0.3.94';
 
   // Skip the DOM bootstrap when required by the Node test shim (ADR-0002).
   const TEST = typeof globalThis !== 'undefined' && globalThis.__RWTH_TEST__ === true;
@@ -789,24 +789,36 @@
     forItem(item, now) {
       const it = item || {};
       const fin = v => (Number.isFinite(v) ? v : null);
+      const buy = fin(it.buyPrice);
+      const ask = fin(it.listPrice);
+      const net = fin(it.saleNet);
       // Guard the raw buy stamp here: spanDays coerces via Number(), so a null
       // stamp would read as 0 (epoch) and yield a bogus multi-thousand-day age.
       const age = (Number.isFinite(it.buyTimestamp) && Number.isFinite(now))
         ? spanDays(it.buyTimestamp, now) : null;
-      return {
-        status: it.status,
-        buy: fin(it.buyPrice),
-        ask: fin(it.listPrice),
-        net: fin(it.saleNet),
-        age,
-      };
+      // ROI distinguishes hope from banked money: a listed row projects off its
+      // ask ((ask-buy)/buy), a sold row realizes off its net ((net-buy)/buy).
+      // roiKind/roiPct stay null when there is no buy basis to divide by (0 or
+      // absent) or the measured leg is missing — never a divide-by-zero or NaN.
+      let roiPct = null, roiKind = null;
+      if (buy != null && buy !== 0) {
+        if (it.status === 'listed' && ask != null) {
+          roiPct = (ask - buy) / buy; roiKind = 'projected';
+        } else if (it.status === 'sold' && net != null) {
+          roiPct = (net - buy) / buy; roiKind = 'realized';
+        }
+      }
+      // Loud only for a guaranteed loss: a listed row whose finite ask sits
+      // below its finite buy. A held/sold row is never flagged below-cost.
+      const belowCost = it.status === 'listed' && ask != null && buy != null && ask < buy;
+      return { status: it.status, buy, ask, net, roiPct, roiKind, age, belowCost };
     },
   };
 
   // Line 2 of a row: the lifecycle strip. A fixed-cell CSS grid (buy / ask /
-  // net / age) so every figure lands in the same column down the list. Legs the
-  // RowModel leaves null (held has no ask/net; listed has no net) render as a
-  // dimmed em-dash so the strip reads consistently across statuses.
+  // net / roi / age) so every figure lands in the same column down the list.
+  // Legs the RowModel leaves null (held has no ask/net; listed has no net)
+  // render as a dimmed em-dash so the strip reads consistently across statuses.
   function rowStrip(m) {
     const cell = (k, v) =>
       `<span class="rwth-cell${v == null ? ' rwth-cell-empty' : ''}">`
@@ -816,8 +828,39 @@
       + cell('buy', m.buy == null ? null : fmtMoney(m.buy))
       + cell('ask', m.ask == null ? null : fmtMoney(m.ask))
       + cell('net', m.net == null ? null : fmtMoney(m.net))
+      + roiCell(m)
       + cell('age', m.age == null ? null : m.age + 'd')
       + `</div>`;
+  }
+
+  // The ROI cell, rendered so hope never reads like banked money: a projected
+  // (listed) ROI is tilde-prefixed and muted (~+47%); a realized (sold) ROI is
+  // solid and P/L-colored (+80%). A below-cost listed ask gets a loud,
+  // distinct marker so a guaranteed loss never reads like a small win. Null
+  // ROI (no buy basis or missing leg) renders the dimmed em-dash like any
+  // not-set leg.
+  function roiCell(m) {
+    if (m.roiPct == null) {
+      return `<span class="rwth-cell rwth-cell-empty">`
+        + `<span class="rwth-cell-k">roi</span>`
+        + `<span class="rwth-cell-v">—</span></span>`;
+    }
+    const pct = Math.round(m.roiPct * 100);
+    const body = (pct >= 0 ? '+' : '') + pct + '%';
+    if (m.belowCost) {
+      return `<span class="rwth-cell rwth-cell-belowcost">`
+        + `<span class="rwth-cell-k">roi</span>`
+        + `<span class="rwth-cell-v">! ${body}</span></span>`;
+    }
+    if (m.roiKind === 'projected') {
+      return `<span class="rwth-cell">`
+        + `<span class="rwth-cell-k">roi</span>`
+        + `<span class="rwth-cell-v rwth-roi-projected">~${body}</span></span>`;
+    }
+    const pl = pct >= 0 ? 'rwth-roi-pos' : 'rwth-roi-neg';
+    return `<span class="rwth-cell">`
+      + `<span class="rwth-cell-k">roi</span>`
+      + `<span class="rwth-cell-v rwth-roi ${pl}">${body}</span></span>`;
   }
 
   function buildLedgerRow(item, expanded, ctx) {
@@ -4600,7 +4643,7 @@
       .rwth-row-bonus { font: 400 11px var(--rwth-font-mono); color: var(--rwth-secondary); }
       .rwth-row-price { font: 600 11px var(--rwth-font-mono); color: var(--rwth-text); }
       .rwth-row-strip {
-        display: grid; grid-template-columns: repeat(4, minmax(0, 1fr));
+        display: grid; grid-template-columns: repeat(5, minmax(0, 1fr));
         gap: 6px; align-items: baseline;
       }
       .rwth-cell { display: flex; align-items: baseline; gap: 4px; min-width: 0; }
@@ -4622,6 +4665,12 @@
       .rwth-roi { font: 700 11px var(--rwth-font-mono); }
       .rwth-roi-pos { color: var(--rwth-accent); }
       .rwth-roi-neg { color: var(--rwth-danger); }
+      .rwth-roi-projected { color: var(--rwth-muted); font-weight: 400; opacity: .85; }
+      .rwth-cell-belowcost .rwth-cell-k { color: var(--rwth-danger); }
+      .rwth-cell-belowcost .rwth-cell-v {
+        color: #fff; background: var(--rwth-danger); font-weight: 700;
+        padding: 0 5px; border-radius: 3px;
+      }
       .rwth-row-detail {
         border-top: 1px solid var(--rwth-border-soft); padding: 8px 9px;
         display: flex; flex-direction: column; gap: 8px;

--- a/test-rowmodel.js
+++ b/test-rowmodel.js
@@ -1,6 +1,7 @@
 // node test-rowmodel.js
-// Tests for RowModel.forItem (issue #336, #325 slice a) — the pure per-row
-// projection a ledger row renders: { status, buy, ask, net, age }. Mirrors
+// Tests for RowModel.forItem (issues #336 slice a, #338 slice b) — the pure
+// per-row projection a ledger row renders:
+// { status, buy, ask, net, roiPct, roiKind, age, belowCost }. Mirrors
 // test-ledgerstats.js's plain-assert style and loads the shipped .user.js
 // directly (ADR-0002 seam) so the real code is exercised. External behavior
 // only: feed an item + injected now, assert the projection.
@@ -65,6 +66,9 @@ console.log('\nheld row');
   assertEq('ask null (no listPrice)', m.ask, null);
   assertEq('net null (not sold)', m.net, null);
   assertEq('age = buy-anchored span', m.age, 3);
+  assertEq('held: no ROI kind', m.roiKind, null);
+  assertEq('held: roiPct null', m.roiPct, null);
+  assertEq('held: not below cost', m.belowCost, false);
 }
 
 // ── listed: buy + ask present, net not-set ────────────────────────────────────
@@ -77,6 +81,9 @@ console.log('\nlisted row');
   assertEq('ask = listPrice', m.ask, 1500);
   assertEq('net null (not sold)', m.net, null);
   assertEq('age buy-anchored', m.age, 3);
+  assertEq('listed: projected ROI kind', m.roiKind, 'projected');
+  assertEq('listed: projected ROI off (ask-buy)/buy', m.roiPct, 0.5);
+  assertEq('listed above cost: not below cost', m.belowCost, false);
 }
 
 // ── sold: all three legs present ──────────────────────────────────────────────
@@ -89,15 +96,54 @@ console.log('\nsold row');
   assertEq('ask = listPrice still present', m.ask, 1500);
   assertEq('net = saleNet', m.net, 1450);
   assertEq('age buy-anchored (now - buy, not sold span)', m.age, 5);
+  assertEq('sold: realized ROI kind', m.roiKind, 'realized');
+  assertEq('sold: realized ROI off (net-buy)/buy', m.roiPct, 0.45);
+  assertEq('sold: never below cost', m.belowCost, false);
 }
 
-// ── below-cost ask is just a smaller number here (no flag in this slice) ───────
+// ── below-cost: a listed ask below buy flags belowCost (loud loss marker) ──────
 
 console.log('\nlisted below cost');
 {
   const m = RowModel.forItem(listed({ listPrice: 800 }), NOW);
   assertEq('ask reflects the low list price', m.ask, 800);
   assertEq('buy unchanged', m.buy, 1000);
+  assertEq('ask < buy -> belowCost true', m.belowCost, true);
+  assertEq('still projected (listed)', m.roiKind, 'projected');
+  assertEq('projected ROI is the negative margin', m.roiPct, -0.2);
+
+  const mEq = RowModel.forItem(listed({ listPrice: 1000 }), NOW);
+  assertEq('ask == buy -> NOT below cost', mEq.belowCost, false);
+  assertEq('ask == buy -> ROI 0', mEq.roiPct, 0);
+
+  const mHeldLow = RowModel.forItem(held({ listPrice: 800 }), NOW);
+  assertEq('held with a stray low list price -> never below cost', mHeldLow.belowCost, false);
+
+  const mSoldLow = RowModel.forItem(sold({ listPrice: 800, saleNet: 700 }), NOW);
+  assertEq('sold -> never below cost (realized, not a live ask)', mSoldLow.belowCost, false);
+}
+
+// ── ROI is null (no kind, no NaN) when there is no basis or the leg is missing ─
+
+console.log('\nROI null cases');
+{
+  const mNoAsk = RowModel.forItem(listed({ listPrice: null }), NOW);
+  assertEq('listed missing ask -> roiKind null', mNoAsk.roiKind, null);
+  assertEq('listed missing ask -> roiPct null', mNoAsk.roiPct, null);
+
+  const mNoNet = RowModel.forItem(sold({ saleNet: null }), NOW);
+  assertEq('sold missing net -> roiKind null', mNoNet.roiKind, null);
+  assertEq('sold missing net -> roiPct null', mNoNet.roiPct, null);
+
+  const mZeroBuy = RowModel.forItem(listed({ buyPrice: 0 }), NOW);
+  assertEq('zero buy -> roiPct null (no divide-by-zero)', mZeroBuy.roiPct, null);
+  assertEq('zero buy -> roiKind null', mZeroBuy.roiKind, null);
+
+  const mNoBuy = RowModel.forItem(listed({ buyPrice: null }), NOW);
+  assertEq('absent buy -> roiPct null', mNoBuy.roiPct, null);
+  assertEq('absent buy -> roiKind null', mNoBuy.roiKind, null);
+  assert('zero/absent buy never yields NaN ROI',
+    [mZeroBuy.roiPct, mNoBuy.roiPct].every(v => v === null || Number.isFinite(v)));
 }
 
 // ── not-set discipline: null / '' never coerced to 0 ──────────────────────────
@@ -150,10 +196,15 @@ console.log('\npartial records');
   assertEq('bare item: net null', m.net, null);
   assertEq('bare item: age null', m.age, null);
 
+  assertEq('bare item: roiPct null', m.roiPct, null);
+  assertEq('bare item: roiKind null', m.roiKind, null);
+  assertEq('bare item: not below cost', m.belowCost, false);
+
   const mNull = RowModel.forItem(null, NOW);
   assertEq('null item: status undefined, no throw', mNull.status, undefined);
-  assert('no NaN in any leg', [mNull.buy, mNull.ask, mNull.net, mNull.age]
+  assert('no NaN in any leg', [mNull.buy, mNull.ask, mNull.net, mNull.age, mNull.roiPct]
     .every(v => v === null || Number.isFinite(v)));
+  assertEq('null item: not below cost', mNull.belowCost, false);
 
   const mStr = RowModel.forItem(held({ buyPrice: '1000' }), NOW);
   assertEq('numeric-string buyPrice -> null (strings are not finite numbers)', mStr.buy, null);


### PR DESCRIPTION
## What

#325 slice b — layer ROI onto the lifecycle row, distinguishing hope from banked money, plus a loud below-cost marker. Closes #338.

### RowModel.forItem
- `roiPct`/`roiKind`: listed -> projected `(ask-buy)/buy`; sold -> realized `(net-buy)/buy`.
- `roiKind: null` + `roiPct: null` when buy is 0/absent or the measured leg is missing — no divide-by-zero, no NaN.
- `belowCost`: true only for a listed row whose finite ask is below buy (held/sold never flagged).

### Row render
- New ROI cell in the lifecycle strip (grid widened to 5 cells).
- Projected -> tilde-prefixed + muted (`~+47%`); realized -> solid + P/L-colored (`+80%`); below-cost -> loud danger marker so a guaranteed loss never reads like a small win.

### Tests
`test-rowmodel.js` extended with the roiKind-per-status / zero-absent-buy / below-cost (ask<buy, ask==buy) / projected-vs-realized matrix. 65/65 pass; `node --check` clean.

`@version` + `SCRIPT_VERSION` bumped to 0.3.94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
